### PR TITLE
[Fix] check version before view appears

### DIFF
--- a/unifest-ios/AppDelegate.swift
+++ b/unifest-ios/AppDelegate.swift
@@ -44,21 +44,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // 파이어베이스 Meesaging 설정
         Messaging.messaging().delegate = self
         
-        VersionService.shared.loadAppStoreVersion { latestVersion in
-            guard let latestVersion else { return }
-            guard let nowVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
-            let compareResult = nowVersion.compare(latestVersion, options: .numeric)
-            print("now version: \(nowVersion)")
-            switch compareResult {
-            case .orderedAscending:
-                VersionService.shared.isOldVersion = true
-            case .orderedDescending:
-                VersionService.shared.isOldVersion = false
-            case .orderedSame:
-                VersionService.shared.isOldVersion = false
-            }
-        }
-        
         return true
     }
 }

--- a/unifest-ios/Views/Root/RootView.swift
+++ b/unifest-ios/Views/Root/RootView.swift
@@ -107,8 +107,14 @@ struct RootView: View {
             }
             
             viewModel.boothModel.loadLikeBoothListDB()
-            
-            if VersionService.shared.isOldVersion {
+            }
+        .task {
+            let versionServce = VersionService.shared
+            guard let latestVersion = try? await versionServce.loadAppStoreVersion() else { return }
+            guard let currentVersion = versionServce.currentVersion() else { return }
+            let cmpResult = currentVersion.compare(latestVersion, options: .numeric)
+            versionServce.isOldVersion = cmpResult == .orderedAscending
+            if versionServce.isOldVersion {
                 print("This app is old. Updated Needed")
                 appVersionAlertPresented = true
             } else {


### PR DESCRIPTION
 현재 구현상으로는 열악한 네트워크 상황인 경우 RootView가 나타난 이후에 버전 정보가 불러와져 버전 체크가 정상 진행하지 않는 코너 케이스가 발생합니다.
 따라서 앱이 실행될 때가 아닌 RootView가 나타날 때 버전 체크를 수행하도록 변경 + swift concurrency 코드로 리팩토링.