### PR TITLE
[Design] #30 - Stamp 탭 추가 및 Stamp관련 뷰 생성

### DIFF
--- a/unifest-ios.xcodeproj/project.pbxproj
+++ b/unifest-ios.xcodeproj/project.pbxproj
@@ -78,6 +78,9 @@
 		F88A6D0D2C77EA640025459F /* WaitingCancelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A6D0C2C77EA640025459F /* WaitingCancelView.swift */; };
 		F88A6D102C7A05570025459F /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A6D0F2C7A05570025459F /* Toast.swift */; };
 		F88A6D122C7A05810025459F /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A6D112C7A05810025459F /* ToastView.swift */; };
+		F8A91F462C81E0B000DA4231 /* StampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A91F452C81E0B000DA4231 /* StampView.swift */; };
+		F8A91F482C81F31B00DA4231 /* StampBoothListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A91F472C81F31B00DA4231 /* StampBoothListView.swift */; };
+		F8A91F4A2C81F68300DA4231 /* StampBoothListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A91F492C81F68300DA4231 /* StampBoothListItemView.swift */; };
 		F8ABA93D2C5A7C28003A8CDB /* Waiting-ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ABA93C2C5A7C28003A8CDB /* Waiting-ViewModel.swift */; };
 		F8ABA93F2C5A7C96003A8CDB /* WaitingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ABA93E2C5A7C96003A8CDB /* WaitingModel.swift */; };
 		F8ABA9422C5A7DEF003A8CDB /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = F8ABA9412C5A7DEF003A8CDB /* Alamofire */; };
@@ -157,6 +160,9 @@
 		F88A6D0C2C77EA640025459F /* WaitingCancelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingCancelView.swift; sourceTree = "<group>"; };
 		F88A6D0F2C7A05570025459F /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		F88A6D112C7A05810025459F /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		F8A91F452C81E0B000DA4231 /* StampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampView.swift; sourceTree = "<group>"; };
+		F8A91F472C81F31B00DA4231 /* StampBoothListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampBoothListView.swift; sourceTree = "<group>"; };
+		F8A91F492C81F68300DA4231 /* StampBoothListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampBoothListItemView.swift; sourceTree = "<group>"; };
 		F8ABA93C2C5A7C28003A8CDB /* Waiting-ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Waiting-ViewModel.swift"; sourceTree = "<group>"; };
 		F8ABA93E2C5A7C96003A8CDB /* WaitingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingModel.swift; sourceTree = "<group>"; };
 		F8AE1AD02C5F8A4000EEB1A8 /* WaitingPinView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingPinView.swift; sourceTree = "<group>"; };
@@ -369,15 +375,16 @@
 			isa = PBXGroup;
 			children = (
 				F88A6D0E2C7A05430025459F /* Toast */,
-				0C9641ED2BB94C8100838DA9 /* Root */,
+				0C4DFCAF2BBEFC1D00CAB98B /* Dialog */,
 				0C244FD12BF685150047F23D /* Welcome */,
 				0CBB05822BB074ED00EB56BE /* Intro */,
+				0C9641ED2BB94C8100838DA9 /* Root */,
 				0CBB05802BB074ED00EB56BE /* Home */,
 				0CBB05862BB074ED00EB56BE /* Map */,
-				0C9641F02BB94DDD00838DA9 /* Waiting */,
-				0C9641F32BB94E7400838DA9 /* Menu */,
-				0C4DFCAF2BBEFC1D00CAB98B /* Dialog */,
 				0CDB46D32BB1DC8300C34AED /* Detail */,
+				0C9641F02BB94DDD00838DA9 /* Waiting */,
+				F8A91F442C81DFD400DA4231 /* Stamp */,
+				0C9641F32BB94E7400838DA9 /* Menu */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -442,6 +449,16 @@
 				F88A6D112C7A05810025459F /* ToastView.swift */,
 			);
 			path = Toast;
+			sourceTree = "<group>";
+		};
+		F8A91F442C81DFD400DA4231 /* Stamp */ = {
+			isa = PBXGroup;
+			children = (
+				F8A91F452C81E0B000DA4231 /* StampView.swift */,
+				F8A91F472C81F31B00DA4231 /* StampBoothListView.swift */,
+				F8A91F492C81F68300DA4231 /* StampBoothListItemView.swift */,
+			);
+			path = Stamp;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -579,10 +596,13 @@
 				F84C6F8F2C4D152200D9E414 /* BoothMenuView.swift in Sources */,
 				0C244FCD2BF67E6B0047F23D /* VersionService.swift in Sources */,
 				F8ABA93F2C5A7C96003A8CDB /* WaitingModel.swift in Sources */,
+				F8A91F4A2C81F68300DA4231 /* StampBoothListItemView.swift in Sources */,
 				0C2AA3C62BFBBBAF008FB5DF /* MenuImageView.swift in Sources */,
 				F88A6D102C7A05570025459F /* Toast.swift in Sources */,
 				F8AE1AD12C5F8A4000EEB1A8 /* WaitingPinView.swift in Sources */,
+				F8A91F462C81E0B000DA4231 /* StampView.swift in Sources */,
 				0C8C41832BB25B5C002B0634 /* AdminLoginView.swift in Sources */,
+				F8A91F482C81F31B00DA4231 /* StampBoothListView.swift in Sources */,
 				F84C6F912C4D1B7D00D9E414 /* BoothFooterView.swift in Sources */,
 				F815E1402C330064002C61DB /* LongSchoolBoxView.swift in Sources */,
 				0CBB058B2BB074ED00EB56BE /* MapPageView.swift in Sources */,

--- a/unifest-ios/Assets.xcassets/ColorSet/UFBoxBackground.colorset/Contents.json
+++ b/unifest-ios/Assets.xcassets/ColorSet/UFBoxBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "blue" : "0xF7",
+          "green" : "0xF3",
+          "red" : "0xF1"
         }
       },
       "idiom" : "universal"

--- a/unifest-ios/Text/StringLiterals.swift
+++ b/unifest-ios/Text/StringLiterals.swift
@@ -10,6 +10,7 @@ enum StringLiterals {
         static let home = "홈"
         static let map = "지도"
         static let waiting = "웨이팅"
+        static let stamp = "스탬프"
         static let menu = "메뉴"
     }
     

--- a/unifest-ios/ViewModel/Waiting-ViewModel.swift
+++ b/unifest-ios/ViewModel/Waiting-ViewModel.swift
@@ -11,8 +11,8 @@ import Foundation
 class WaitingViewModel: ObservableObject {
     @Published var waitingTeamCount: Int = -1
         // WaitingRequestView와 WaitingComplete에서 웨이팅 팀 수를 보여주는 변수
-    @Published var requestedWaitingInfo: AddWaitingResult? = nil // .empty
-    @Published var reservedWaitingList: [ReservedWaitingResult]? = nil // [.empty]
+    @Published var requestedWaitingInfo: AddWaitingResult? = .empty // .empty
+    @Published var reservedWaitingList: [ReservedWaitingResult]? = [.empty] // [.empty]
     @Published var isValidPinNumber: Bool? = nil
     /// 사용자의 웨이팅 취소
     func cancelWaiting(waitingId: Int, deviceId: String) async {

--- a/unifest-ios/Views/Root/RootView.swift
+++ b/unifest-ios/Views/Root/RootView.swift
@@ -75,6 +75,15 @@ struct RootView: View {
                         }
                         .tag(2)
                     
+                    StampView(viewModel: viewModel)
+                        .onAppear {
+                            HapticManager.shared.hapticImpact(style: .light)
+                        }
+                        .tabItem {
+                            Label(StringLiterals.Root.stamp, systemImage: "star.circle")
+                        }
+                        .tag(3)
+                    
                     MenuView(viewModel: viewModel)
                         .onAppear {
                             HapticManager.shared.hapticImpact(style: .light)
@@ -85,7 +94,7 @@ struct RootView: View {
                             // Text(StringLiterals.Root.menu)
                             Label(StringLiterals.Root.menu, systemImage: "line.3.horizontal.circle")
                         }
-                        .tag(3)
+                        .tag(4)
                 }
                 .environmentObject(tabSelect)
                 .environmentObject(waitingVM)

--- a/unifest-ios/Views/Stamp/StampBoothListItemView.swift
+++ b/unifest-ios/Views/Stamp/StampBoothListItemView.swift
@@ -1,0 +1,97 @@
+//
+//  StampBoothListItemView.swift
+//  unifest-ios
+//
+//  Created by 임지성 on 8/30/24.
+//
+
+import SwiftUI
+
+struct StampBoothListItemView: View {
+    @ObservedObject var viewModel: RootViewModel
+    let boothID: Int
+    let image: String
+    let name: String
+    let description: String
+    let location: String
+    @State private var isBoothDetailViewPresented = false
+    
+    var body: some View {
+        HStack {
+            AsyncImage(url: URL(string: image)) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 86, height: 86)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+            } placeholder: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(.lightGray)
+                        .frame(width: 86, height: 86)
+                    
+                    Image(.noImagePlaceholder)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 50, height: 50)
+                }
+                .frame(width: 86, height: 86)
+            }
+            .padding(.trailing, 4)
+            
+            /* Image(image)
+             .resizable()
+             .scaledToFill()
+             .frame(width: 86, height: 86)
+             .clipShape(RoundedRectangle(cornerRadius: 10))
+             .padding(.trailing, 4)*/
+            
+            VStack(alignment: .leading) {
+                Text(name)
+                    .font(.pretendard(weight: .p6, size: 18))
+                    .foregroundStyle(.grey900)
+                    .lineLimit(1)
+                    .padding(.top, 5)
+                
+                /* Button {
+                 GATracking.sendLogEvent(GATracking.LogEventType.MenuView.MENU_BOOTH_LIKE_CANCEL, params: ["boothID": boothID])
+                 viewModel.boothModel.deleteLikeBoothListDB(boothID)
+                 } label: {
+                 Image(.pinkBookMark)
+                 }*/
+                
+                Text(description)
+                    .font(.pretendard(weight: .p6, size: 13))
+                    .foregroundStyle(.grey600)
+                    .lineLimit(2)
+                    .padding(.top, -7)
+                
+                Spacer()
+                
+                HStack(spacing: 2) {
+                    Image(.marker)
+                        .padding(.trailing, 5)
+                    Text(location)
+                        .font(.pretendard(weight: .p6, size: 13))
+                        .foregroundStyle(.grey700)
+                        .lineLimit(1)
+                    Spacer()
+                }
+                .padding(.bottom, 6)
+            }
+        }
+        .background(.ufBackground)
+        .frame(height: 90)
+        .onTapGesture {
+            viewModel.boothModel.loadBoothDetail(boothID)
+            isBoothDetailViewPresented = true
+        }
+        .sheet(isPresented: $isBoothDetailViewPresented) {
+            BoothDetailView(viewModel: viewModel, currentBoothId: boothID)
+        }
+    }
+}
+
+#Preview {
+    StampBoothListItemView(viewModel: RootViewModel(), boothID: 159, image: "", name: "Example Booth", description: "Example Description", location: "Example Location")
+}

--- a/unifest-ios/Views/Stamp/StampBoothListView.swift
+++ b/unifest-ios/Views/Stamp/StampBoothListView.swift
@@ -1,0 +1,49 @@
+//
+//  StampBoothView.swift
+//  unifest-ios
+//
+//  Created by 임지성 on 8/30/24.
+//
+
+import SwiftUI
+
+struct StampBoothListView: View {
+    @ObservedObject var viewModel: RootViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                Text("한국교통대학교")
+                    .font(.pretendard(weight: .p4, size: 14))
+                    .foregroundStyle(.grey500)
+                    .padding(.bottom, -1)
+                
+                Text("스탬프 가능 부스")
+                    .font(.pretendard(weight: .p6, size: 20))
+                    .foregroundStyle(.grey900)
+                    .padding(.bottom, 8)
+                
+                Text("총 12개")
+                    .font(.pretendard(weight: .p6, size: 13))
+                    .foregroundStyle(.grey600)
+            }
+            .padding(.horizontal, 22)
+            .padding(.top, 30)
+            
+            List {
+                ForEach(0 ..< 12) { _ in
+                    StampBoothListItemView(viewModel: viewModel, boothID: 156, image: "", name: "컴공 주점 부스", description: "저희 주점은 일본 이자카야를 보티브로 만든 컴공인을 위한 주점입니다", location: "학생회관 옆")
+                        .listRowBackground(Color.ufBackground)
+                        .listRowSeparator(.hidden)
+                }
+            }
+            .background(.ufBackground)
+            .listStyle(.plain)
+        }
+        .background(.ufBackground)
+    }
+}
+
+#Preview {
+    StampBoothListView(viewModel: RootViewModel())
+}

--- a/unifest-ios/Views/Stamp/StampView.swift
+++ b/unifest-ios/Views/Stamp/StampView.swift
@@ -1,0 +1,168 @@
+//
+//  StampView.swift
+//  unifest-ios
+//
+//  Created by 임지성 on 8/30/24.
+//
+
+import SwiftUI
+
+struct StampView: View {
+    @ObservedObject var viewModel: RootViewModel
+    @State private var rotationAmount = 0.0
+    @State private var isStampBoothViewPresented = false
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text("스탬프")
+                    .font(.pretendard(weight: .p6, size: 21))
+                    .foregroundStyle(.grey900)
+                
+                Spacer()
+            }
+            .padding(.bottom, 20)
+            
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.ufBoxBackground)
+                .frame(width: 353, height: 530)
+                .overlay {
+                    VStack {
+                        HStack {
+                            VStack {
+                                Text("한국교통대학교")
+                                    .font(.pretendard(weight: .p6, size: 20))
+                                    .foregroundStyle(.grey900)
+                                    .padding(.bottom, 3)
+                                
+                                Text("지금까지 모은 스탬프")
+                                    .font(.pretendard(weight: .p4, size: 14))
+                                    .foregroundStyle(.grey500)
+                                    .padding(.trailing, 2)
+                            }
+                            
+                            Spacer()
+                            
+                            Button {
+                                
+                            } label: {
+                                Capsule()
+                                    .fill(
+                                        LinearGradient(
+                                            gradient: Gradient(stops: [
+                                                .init(color: Color(red: 1.0, green: 0.525, blue: 0.6), location: 0.0),
+                                                .init(color: Color(red: 1.0, green: 0.258, blue: 0.392), location: 1.0),
+                                                .init(color: Color(red: 0.937, green: 0.224, blue: 1.0), location: 1.0)
+                                            ]),
+                                            startPoint: .topLeading,
+                                            endPoint: .bottom
+                                        )
+                                    )
+                                    .frame(width: 140, height: 52)
+                                    .overlay {
+                                        Text("스탬프 받기")
+                                            .font(.pretendard(weight: .p6, size: 18))
+                                            .foregroundStyle(.ufWhite)
+                                    }
+                            }
+                        }
+                        .padding(.top, 18)
+                        .padding(.bottom, 20)
+                        
+                        HStack {
+                            HStack {
+                                Text("1")
+                                    .foregroundStyle(.grey900)
+                                Text("/ 12개")
+                                    .foregroundStyle(.grey500)
+                            }
+                            .font(.pretendard(weight: .p7, size: 24))
+                            
+                            Spacer()
+                            
+                            Button {
+                                
+                            } label: {
+                                Label("새로고침", systemImage: "arrow.triangle.2.circlepath")
+                                    .font(.system(size: 14))
+                                    .foregroundStyle(.grey600)
+                            }
+                            .padding(.trailing, 8)
+                        }
+                        .padding(.bottom, 20)
+                        
+                        Grid {
+                            ForEach(0 ..< 3) { row in
+                                GridRow {
+                                    ForEach(0 ..< 4) { _ in
+                                        // 스탬프 개수에 따라
+                                        // let emptyCircle = Circle() 생성하고
+                                        // 현재 스탬프 개수 if문으로 emptyCircle 대신 Image(.appLogo) 띄우는 식?
+                                        
+                                        Circle()
+                                            .fill(Color.grey200)
+                                            .frame(width: 62, height: 62)
+                                            .overlay {
+                                                Image(.appLogo)
+                                                    .resizable()
+                                                    .frame(width: 62, height: 62)
+                                                    .clipShape(Circle())
+                                            }
+                                            .onTapGesture {
+                                                HapticManager.shared.hapticImpact(style: .light)
+//                                                withAnimation(.spring(duration: 1, bounce: 0.7)) {
+//                                                    rotationAmount += 360
+//                                                }
+                                            }
+//                                            .rotation3DEffect(
+//                                                .degrees(rotationAmount),
+//                                                axis: (x: 1, y: 1, z: 1)
+//                                            )
+                                            .padding(.horizontal, 7)
+                                            .padding(.vertical, 8)
+                                    }
+                                }
+                            }
+                        }
+                        
+                        Spacer()
+                        
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(Color.ufBackground)
+                            .frame(width: 305, height: 50)
+                            .overlay {
+                                Button {
+                                    isStampBoothViewPresented = true
+                                } label: {
+                                    HStack {
+                                        Text("스탬프 부스 찾아보기")
+                                            .font(.pretendard(weight: .p6, size: 15))
+                                            .foregroundStyle(.grey700)
+                                        
+                                        Spacer()
+                                        
+                                        Image(systemName: "chevron.right")
+                                            .foregroundStyle(.grey700)
+                                    }
+                                    .padding(.horizontal)
+                                }
+                            }
+                            .padding(.bottom, 5)
+                    }
+                    .padding()
+                }
+            
+            Spacer()
+        }
+        .padding()
+        .background(.ufBackground)
+        .sheet(isPresented: $isStampBoothViewPresented) {
+            StampBoothListView(viewModel: viewModel)
+                .presentationDragIndicator(.visible)
+        }
+    }
+}
+
+#Preview {
+    StampView(viewModel: RootViewModel())
+}


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue

<br/>

### 🌟Motivation

<br/>

### 🌟Key Changes

* TabView에 스탬프 탭 추가

* 스탬프를 확인하는 StampView, 스탬프 부스를 확인할 수 있는 StampBoothListView, StampBoothListItemView를 생성하고 Stamp그룹에 추가함, StampBoothListView에서 BoothDetailView를 sheet로 열 수 있도록 구현

* 새로 생성된 뷰들은 모두 다크모드까지 지원되도록 구현함

<br/>

### 🌟Simulation
// UI를 구현했다면 시연영상은 필수 !

https://github.com/user-attachments/assets/d262cb88-15df-44a7-ba05-153a4e5c7079



### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
