### PR TITLE
[Fix] #36 - 뷰 관련 간단한 수정

### DIFF
--- a/unifest-ios.xcodeproj/project.pbxproj
+++ b/unifest-ios.xcodeproj/project.pbxproj
@@ -56,7 +56,6 @@
 		F800716B2C3648390001596F /* WaitingInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F800716A2C3648390001596F /* WaitingInfoView.swift */; };
 		F8059A1C2C7C94730061431E /* IntroView-ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8059A1B2C7C94730061431E /* IntroView-ViewModel.swift */; };
 		F815E1402C330064002C61DB /* LongSchoolBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F815E13F2C330064002C61DB /* LongSchoolBoxView.swift */; };
-		F820FD2F2C859ABF00010BB6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F820FD2E2C859ABF00010BB6 /* GoogleService-Info.plist */; };
 		F84C6F782C4A3A8200D9E414 /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F84C6F6F2C4A3A7F00D9E414 /* Pretendard-SemiBold.ttf */; };
 		F84C6F792C4A3A8200D9E414 /* Pretendard-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F84C6F702C4A3A8000D9E414 /* Pretendard-Medium.ttf */; };
 		F84C6F7A2C4A3A8200D9E414 /* Pretendard-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F84C6F712C4A3A8000D9E414 /* Pretendard-Thin.ttf */; };
@@ -78,6 +77,7 @@
 		F88A6D0D2C77EA640025459F /* WaitingCancelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A6D0C2C77EA640025459F /* WaitingCancelView.swift */; };
 		F88A6D102C7A05570025459F /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A6D0F2C7A05570025459F /* Toast.swift */; };
 		F88A6D122C7A05810025459F /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88A6D112C7A05810025459F /* ToastView.swift */; };
+		F8A538BA2C8D056200103E64 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8A538B92C8D056200103E64 /* GoogleService-Info.plist */; };
 		F8A91F462C81E0B000DA4231 /* StampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A91F452C81E0B000DA4231 /* StampView.swift */; };
 		F8A91F482C81F31B00DA4231 /* StampBoothListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A91F472C81F31B00DA4231 /* StampBoothListView.swift */; };
 		F8A91F4A2C81F68300DA4231 /* StampBoothListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A91F492C81F68300DA4231 /* StampBoothListItemView.swift */; };
@@ -139,7 +139,6 @@
 		F800716A2C3648390001596F /* WaitingInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingInfoView.swift; sourceTree = "<group>"; };
 		F8059A1B2C7C94730061431E /* IntroView-ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntroView-ViewModel.swift"; sourceTree = "<group>"; };
 		F815E13F2C330064002C61DB /* LongSchoolBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongSchoolBoxView.swift; sourceTree = "<group>"; };
-		F820FD2E2C859ABF00010BB6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F84C6F6F2C4A3A7F00D9E414 /* Pretendard-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.ttf"; sourceTree = "<group>"; };
 		F84C6F702C4A3A8000D9E414 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.ttf"; sourceTree = "<group>"; };
 		F84C6F712C4A3A8000D9E414 /* Pretendard-Thin.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.ttf"; sourceTree = "<group>"; };
@@ -161,6 +160,7 @@
 		F88A6D0C2C77EA640025459F /* WaitingCancelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingCancelView.swift; sourceTree = "<group>"; };
 		F88A6D0F2C7A05570025459F /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		F88A6D112C7A05810025459F /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		F8A538B92C8D056200103E64 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F8A91F452C81E0B000DA4231 /* StampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampView.swift; sourceTree = "<group>"; };
 		F8A91F472C81F31B00DA4231 /* StampBoothListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampBoothListView.swift; sourceTree = "<group>"; };
 		F8A91F492C81F68300DA4231 /* StampBoothListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampBoothListItemView.swift; sourceTree = "<group>"; };
@@ -285,7 +285,7 @@
 		0C9D0A5A2BA19DFE00156763 /* unifest-ios */ = {
 			isa = PBXGroup;
 			children = (
-				F820FD2E2C859ABF00010BB6 /* GoogleService-Info.plist */,
+				F8A538B92C8D056200103E64 /* GoogleService-Info.plist */,
 				0CA4E1122BF3EC69000B1B1B /* unifest-ios.entitlements */,
 				0C2A2C032BE9AEA600EDF359 /* Info.plist */,
 				0C9D0A5B2BA19DFE00156763 /* unifest_iosApp.swift */,
@@ -547,7 +547,7 @@
 				0CB2170F2BF23F270003338B /* festivalTest.json in Resources */,
 				F84C6F7E2C4A3A8200D9E414 /* Pretendard-Bold.ttf in Resources */,
 				F84C6F7D2C4A3A8200D9E414 /* Pretendard-ExtraLight.ttf in Resources */,
-				F820FD2F2C859ABF00010BB6 /* GoogleService-Info.plist in Resources */,
+				F8A538BA2C8D056200103E64 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -774,7 +774,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.4;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.hoeunlee228.unifest-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hoeunlee228.unifest-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -817,7 +817,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.3.4;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.hoeunlee228.unifest-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hoeunlee228.unifest-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/unifest-ios/GoogleService-Info.plist
+++ b/unifest-ios/GoogleService-Info.plist
@@ -9,7 +9,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.hoeunlee228.unifest-app</string>
+	<string>com.hoeunlee228.unifest-ios</string>
 	<key>PROJECT_ID</key>
 	<string>unifest-b2ea8</string>
 	<key>STORAGE_BUCKET</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:1031417698921:ios:fd8f35832dc185704fa0f8</string>
+	<string>1:1031417698921:ios:d02bddd0adadfe404fa0f8</string>
 </dict>
 </plist>

--- a/unifest-ios/Views/Detail/BoothInfoView.swift
+++ b/unifest-ios/Views/Detail/BoothInfoView.swift
@@ -142,7 +142,7 @@ struct BoothInfoView: View {
                             Text(viewModel.boothModel.selectedBooth?.warning ?? "")
                                 .font(.pretendard(weight: .p6, size: 10))
                                 .foregroundStyle(.primary500)
-                                .lineLimit(3)
+                                // .lineLimit(3)
                         }
                     }
                 }

--- a/unifest-ios/Views/Map/MapPageView.swift
+++ b/unifest-ios/Views/Map/MapPageView.swift
@@ -14,6 +14,9 @@ import SwiftUI
 // ZStack에 MapView(MapViewiOS17, mapViewiOS16)를 띄우고, 
 // 그 위에 VStack으로 MapPageHeaderView와 밑에 보이는 '인기부스' 버튼을 묶어서 띄움
 
+// isPopularBoothPresented: '인기 부스' 버튼을 탭할 때 true/false
+// isBoothListPresented: map의 annotation을 탭했을 때 true/false
+
 struct MapPageView: View {
     @ObservedObject var viewModel: RootViewModel
     @ObservedObject var mapViewModel: MapViewModel
@@ -128,42 +131,50 @@ struct MapPageView: View {
                 
                 // isPopularBoothPresented: '인기 부스' 버튼을 탭할 때 true/false
                 // isBoothListPresented: map의 annotation을 탭했을 때 true/false
-                if mapViewModel.isPopularBoothPresented || mapViewModel.isBoothListPresented {
-                    VStack {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 12) {
-                                if mapViewModel.isPopularBoothPresented {
-                                    ForEach(Array(viewModel.boothModel.top5booths.enumerated()), id: \.1) { index, topBooth in
-                                        BoothBox(rank: index, title: topBooth.name, description: topBooth.description, position: topBooth.location, imageURL: topBooth.thumbnail)
-                                            .onTapGesture {
-                                                GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLOSE_FABOR_BOOTH, params: ["boothID": topBooth.id])
-                                                viewModel.boothModel.loadBoothDetail(topBooth.id)
-                                                isBoothDetailViewPresented = true
-                                            }
-                                    }
-                                } else {
-                                    if viewModel.boothModel.mapSelectedBoothList.isEmpty {
-                                        //
-                                    } else {
-                                        ForEach(viewModel.boothModel.mapSelectedBoothList, id: \.self) { booth in
-                                            BoothBox(rank: -1, title: booth.name, description: booth.description, position: booth.location, imageURL: booth.thumbnail)
+                HStack {
+                    Spacer()
+                    
+                    if mapViewModel.isPopularBoothPresented || mapViewModel.isBoothListPresented {
+                        VStack {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 12) {
+                                    if mapViewModel.isPopularBoothPresented {
+                                        ForEach(Array(viewModel.boothModel.top5booths.enumerated()), id: \.1) { index, topBooth in
+                                            BoothBox(rank: index, title: topBooth.name, description: topBooth.description, position: topBooth.location, imageURL: topBooth.thumbnail)
                                                 .onTapGesture {
-                                                    GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLICK_BOOTH_ROW, params: ["boothID": booth.id])
-                                                    viewModel.boothModel.loadBoothDetail(booth.id)
-                                                    tappedBoothId = booth.id
+                                                    GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLOSE_FABOR_BOOTH, params: ["boothID": topBooth.id])
+                                                    viewModel.boothModel.loadBoothDetail(topBooth.id)
                                                     isBoothDetailViewPresented = true
                                                 }
                                         }
+                                    } else {
+                                        if viewModel.boothModel.mapSelectedBoothList.isEmpty {
+                                            //
+                                        } else {
+                                            ForEach(viewModel.boothModel.mapSelectedBoothList, id: \.self) { booth in
+                                                BoothBox(rank: -1, title: booth.name, description: booth.description, position: booth.location, imageURL: booth.thumbnail)
+                                                    .onTapGesture {
+                                                        GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLICK_BOOTH_ROW, params: ["boothID": booth.id])
+                                                        viewModel.boothModel.loadBoothDetail(booth.id)
+                                                        tappedBoothId = booth.id
+                                                        isBoothDetailViewPresented = true
+                                                    }
+                                            }
+                                        }
                                     }
                                 }
+                                .padding(.horizontal, 35)
+                                .frame(maxWidth: .infinity) // HStack을 화면 너비만큼 확장
                             }
-                            .padding(.horizontal, 35)
+                            .padding(.bottom)
+                            
+                            Spacer()
+                                .frame(height: 80)
                         }
-                        .padding(.bottom)
-                        
-                        Spacer()
-                            .frame(height: 80)
+                        .frame(maxWidth: .infinity)
                     }
+                    
+                    Spacer() // 우측 여백
                 }
             }
             

--- a/unifest-ios/Views/Menu/LikeBoothListView.swift
+++ b/unifest-ios/Views/Menu/LikeBoothListView.swift
@@ -88,7 +88,7 @@ struct LikeBoothListView: View {
                 }
                 .background(.ufBackground)
                 .listStyle(.plain)
-                .padding(.top, 115)
+                .padding(.top, 123)
             }
             
             VStack {

--- a/unifest-ios/Views/Menu/LikedBoothBoxView.swift
+++ b/unifest-ios/Views/Menu/LikedBoothBoxView.swift
@@ -81,7 +81,7 @@ struct LikedBoothBoxView: View {
             }
         }
         .background(.ufBackground)
-        .frame(height: 90)
+        .frame(height: 95)
         // .padding(.horizontal)
     }
 }

--- a/unifest-ios/Views/Stamp/StampBoothListItemView.swift
+++ b/unifest-ios/Views/Stamp/StampBoothListItemView.swift
@@ -81,7 +81,7 @@ struct StampBoothListItemView: View {
             }
         }
         .background(.ufBackground)
-        .frame(height: 90)
+        .frame(height: 95)
         .onTapGesture {
             viewModel.boothModel.loadBoothDetail(boothID)
             isBoothDetailViewPresented = true

--- a/unifest-ios/Views/Stamp/StampView.swift
+++ b/unifest-ios/Views/Stamp/StampView.swift
@@ -17,127 +17,131 @@ struct StampView: View {
     @State private var addStampToast: Toast? = nil
     
     var body: some View {
-        VStack {
-            HStack {
-                Text("스탬프")
-                    .font(.pretendard(weight: .p6, size: 21))
-                    .foregroundStyle(.grey900)
+        GeometryReader { geometry in
+            let screenWidth = geometry.size.width
+            
+            VStack {
+                HStack {
+                    Text("스탬프")
+                        .font(.pretendard(weight: .p6, size: 21))
+                        .foregroundStyle(.grey900)
+                    
+                    Spacer()
+                }
+                .padding(.bottom, 20)
+                
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.ufBoxBackground)
+                    .frame(width: screenWidth * 0.9, height: 530)
+                    .overlay {
+                        VStack {
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text("한국교통대학교")
+                                        .font(.pretendard(weight: .p6, size: 20))
+                                        .foregroundStyle(.grey900)
+                                        .padding(.bottom, 3)
+                                    
+                                    Text("지금까지 모은 스탬프")
+                                        .font(.pretendard(weight: .p4, size: 14))
+                                        .foregroundStyle(.grey500)
+                                }
+                                
+                                Spacer()
+                                
+                                Button {
+                                    isShowingScanner = true
+                                } label: {
+                                    Capsule()
+                                        .fill(
+                                            LinearGradient(
+                                                gradient: Gradient(stops: [
+                                                    .init(color: Color(red: 1.0, green: 0.525, blue: 0.6), location: 0.0),
+                                                    .init(color: Color(red: 1.0, green: 0.258, blue: 0.392), location: 1.0),
+                                                    .init(color: Color(red: 0.937, green: 0.224, blue: 1.0), location: 1.0)
+                                                ]),
+                                                startPoint: .topLeading,
+                                                endPoint: .bottom
+                                            )
+                                        )
+                                        .frame(width: 140, height: 52)
+                                        .overlay {
+                                            Text("스탬프 받기")
+                                                .font(.pretendard(weight: .p6, size: 18))
+                                                .foregroundStyle(.ufWhite)
+                                        }
+                                }
+                            }
+                            .padding(.top, 18)
+                            .padding(.bottom, 20)
+                            
+                            HStack {
+                                HStack {
+                                    Text("\(numberOfStamps)")
+                                        .foregroundStyle(.grey900)
+                                    Text("/ 12개")
+                                        .foregroundStyle(.grey500)
+                                }
+                                .font(.pretendard(weight: .p7, size: 24))
+                                
+                                
+                                Spacer()
+                                
+                                Button {
+                                    
+                                } label: {
+                                    Label("새로고침", systemImage: "arrow.triangle.2.circlepath")
+                                        .font(.system(size: 14))
+                                        .foregroundStyle(.grey600)
+                                }
+                                .padding(.trailing, 8)
+                            }
+                            .padding(.bottom, 20)
+                            
+                            StampGrid(numberOfStamps: numberOfStamps, screenWidth: screenWidth)
+                            
+                            Spacer()
+                            
+                            RoundedRectangle(cornerRadius: 7)
+                                .fill(Color.ufBackground)
+                                .frame(width: 305, height: 50)
+                                .overlay {
+                                    Button {
+                                        isStampBoothViewPresented = true
+                                    } label: {
+                                        HStack {
+                                            Text("스탬프 부스 찾아보기")
+                                                .font(.pretendard(weight: .p6, size: 15))
+                                                .foregroundStyle(.grey700)
+                                            
+                                            Spacer()
+                                            
+                                            Image(systemName: "chevron.right")
+                                                .foregroundStyle(.grey700)
+                                        }
+                                        .padding(.horizontal)
+                                    }
+                                }
+                                .padding(.bottom, 5)
+                        }
+                        .padding()
+                    }
                 
                 Spacer()
             }
-            .padding(.bottom, 20)
-            
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.ufBoxBackground)
-                .frame(width: 353, height: 530)
-                .overlay {
-                    VStack {
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text("한국교통대학교")
-                                    .font(.pretendard(weight: .p6, size: 20))
-                                    .foregroundStyle(.grey900)
-                                    .padding(.bottom, 3)
-                                
-                                Text("지금까지 모은 스탬프")
-                                    .font(.pretendard(weight: .p4, size: 14))
-                                    .foregroundStyle(.grey500)
-                            }
-                            
-                            Spacer()
-                            
-                            Button {
-                                isShowingScanner = true
-                            } label: {
-                                Capsule()
-                                    .fill(
-                                        LinearGradient(
-                                            gradient: Gradient(stops: [
-                                                .init(color: Color(red: 1.0, green: 0.525, blue: 0.6), location: 0.0),
-                                                .init(color: Color(red: 1.0, green: 0.258, blue: 0.392), location: 1.0),
-                                                .init(color: Color(red: 0.937, green: 0.224, blue: 1.0), location: 1.0)
-                                            ]),
-                                            startPoint: .topLeading,
-                                            endPoint: .bottom
-                                        )
-                                    )
-                                    .frame(width: 140, height: 52)
-                                    .overlay {
-                                        Text("스탬프 받기")
-                                            .font(.pretendard(weight: .p6, size: 18))
-                                            .foregroundStyle(.ufWhite)
-                                    }
-                            }
-                        }
-                        .padding(.top, 18)
-                        .padding(.bottom, 20)
-                        
-                        HStack {
-                            HStack {
-                                Text("\(numberOfStamps)")
-                                    .foregroundStyle(.grey900)
-                                Text("/ 12개")
-                                    .foregroundStyle(.grey500)
-                            }
-                            .font(.pretendard(weight: .p7, size: 24))
-                            
-                            
-                            Spacer()
-                            
-                            Button {
-                                
-                            } label: {
-                                Label("새로고침", systemImage: "arrow.triangle.2.circlepath")
-                                    .font(.system(size: 14))
-                                    .foregroundStyle(.grey600)
-                            }
-                            .padding(.trailing, 8)
-                        }
-                        .padding(.bottom, 20)
-                        
-                        StampGrid(numberOfStamps: numberOfStamps)
-                        
-                        Spacer()
-                        
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(Color.ufBackground)
-                            .frame(width: 305, height: 50)
-                            .overlay {
-                                Button {
-                                    isStampBoothViewPresented = true
-                                } label: {
-                                    HStack {
-                                        Text("스탬프 부스 찾아보기")
-                                            .font(.pretendard(weight: .p6, size: 15))
-                                            .foregroundStyle(.grey700)
-                                        
-                                        Spacer()
-                                        
-                                        Image(systemName: "chevron.right")
-                                            .foregroundStyle(.grey700)
-                                    }
-                                    .padding(.horizontal)
-                                }
-                            }
-                            .padding(.bottom, 5)
-                    }
-                    .padding()
-                }
-            
-            Spacer()
-        }
-        .padding()
-        .background(.ufBackground)
-        .sheet(isPresented: $isStampBoothViewPresented) {
-            StampBoothListView(viewModel: viewModel)
-                .presentationDragIndicator(.visible)
-        }
-        .sheet(isPresented: $isShowingScanner) {
-            CodeScannerView(codeTypes: [.qr], completion: handleScan)
-                .presentationDragIndicator(.visible)
-                .ignoresSafeArea()
-        }
+            .padding()
+            .background(.ufBackground)
+            .sheet(isPresented: $isStampBoothViewPresented) {
+                StampBoothListView(viewModel: viewModel)
+                    .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $isShowingScanner) {
+                CodeScannerView(codeTypes: [.qr], completion: handleScan)
+                    .presentationDragIndicator(.visible)
+                    .ignoresSafeArea()
+            }
         .toastView(toast: $addStampToast)
+        }
     }
     
     func handleScan(result: Result<ScanResult, ScanError>) {
@@ -158,6 +162,7 @@ struct StampView: View {
 
 struct StampGrid: View {
     let numberOfStamps: Int
+    let screenWidth: CGFloat
     
     var body: some View {
         Grid {
@@ -171,17 +176,24 @@ struct StampGrid: View {
                                 .resizable()
                                 .frame(width: 62, height: 62)
                                 .clipShape(Circle())
-                                .padding(.horizontal, 7)
+                                .padding(.horizontal, screenWidth * 0.0215)
                                 .padding(.vertical, 8)
                                 .onTapGesture {
                                     HapticManager.shared.hapticImpact(style: .light)
                                 }
                         } else {
-                            Circle()
-                                .fill(Color.grey300)
-                                .frame(width: 62, height: 62)
-                                .padding(.horizontal, 7)
-                                .padding(.vertical, 8)
+                            ZStack {
+                                Circle()
+                                    .fill(Color.grey300)
+                                    .frame(width: 62, height: 62)
+                                
+                                Image(.noImagePlaceholder)
+                                    .resizable()
+                                    .frame(width: 42, height: 42)
+                                    .offset(x: 2, y: -2)
+                            }
+                            .padding(.horizontal, screenWidth * 0.0215)
+                            .padding(.vertical, 8)
                         }
                     }
                 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue

<br/>

### 🌟Motivation

<br/>

### 🌟Key Changes

* 화면 크기(Pro Max까지 고려)에 따라 뷰의 크기를 조절하는 코드 추가(StampView와 MapPageView) 

* 부스 관리자가 입력한 내용이 BoothInfoView에서 모두 보여지도록 lineLimit 제거(관리자 페이지에서 입력 글자수 제한 이미 있음) 

* 부스에 대한 간략한 소개를 보여주는 BoxView의 높이를 90에서 95로 조정해서 부스 소개가 두 줄까지 보여지도록 수정함 

* FCM 연동을 위해 GoogleService-Info.plist 업데이트

### 🌟Simulation
// UI를 구현했다면 시연영상은 필수 !

<br/>

### 🌟To Reviewer

<br/>

### 🌟Reference

<br/>
