### PR TITLE
[Design, Fix, Feat] #40 - 다양한 수정 및 추가사항

### DIFF
--- a/unifest-ios/Data/BoothData.swift
+++ b/unifest-ios/Data/BoothData.swift
@@ -74,6 +74,8 @@ struct BoothDetailItem: Codable, Hashable, Identifiable {
     var menus: [MenuItem]?
     var enabled: Bool?
     var waitingEnabled: Bool
+    var openTime: String?
+    var closeTime: String?
 }
 
 struct MenuItem: Codable, Hashable, Identifiable {

--- a/unifest-ios/Data/BoothData.swift
+++ b/unifest-ios/Data/BoothData.swift
@@ -73,6 +73,7 @@ struct BoothDetailItem: Codable, Hashable, Identifiable {
     var longitude: Double
     var menus: [MenuItem]?
     var enabled: Bool?
+    var waitingEnabled: Bool
 }
 
 struct MenuItem: Codable, Hashable, Identifiable {
@@ -80,6 +81,7 @@ struct MenuItem: Codable, Hashable, Identifiable {
     var name: String?
     var price: Int?
     var imgUrl: String?
+    var menuStatus: String?
 }
 
 struct APIResponseIntData: Codable {

--- a/unifest-ios/Text/StringLiterals.swift
+++ b/unifest-ios/Text/StringLiterals.swift
@@ -82,6 +82,7 @@ enum StringLiterals {
         static let copyright = "UNIFEST 2024 © ALL RIGHT RESERVED"
         static let TeamTitle = "Team UNIFEST"
         static let locationAuthText = "위치 권한 수정"
+        static let cameraAuthText = "카메라 권한 수정"
         static let developerMail = "개발자에게 메일 보내기"
         static let privacyText = "개인정보 처리방침"
         static let clearApp = "앱 데이터 초기화"

--- a/unifest-ios/ViewModel/Waiting-ViewModel.swift
+++ b/unifest-ios/ViewModel/Waiting-ViewModel.swift
@@ -280,7 +280,6 @@ class WaitingViewModel: ObservableObject {
                         }
                     }
                     
-                    print("CheckPinNumber 작업 종료")
                     continuation.resume() // async 작업 종료
                 }
             }

--- a/unifest-ios/Views/Detail/BoothFooterView.swift
+++ b/unifest-ios/Views/Detail/BoothFooterView.swift
@@ -71,29 +71,33 @@ struct BoothFooterView: View {
                         }
                     }
                 } label: {
-                    Text("")
-//                        .roundedButton(background: .defaultDarkGray, strokeColor: .clear, height: 45, cornerRadius: 10)
-                        .roundedButton(background: .primary500, strokeColor: .clear, height: 45, cornerRadius: 10)
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(viewModel.boothModel.selectedBooth?.waitingEnabled ?? false ? .primary500 : .grey600)
+                        .frame(width: 316, height: 45)
                         .overlay {
-//                            if viewModel.boothModel.selectedBooth == nil {
-//                                if !isReloadButtonPresent {
-//                                    ProgressView()
-//                                } else {
-//                                    Text(StringLiterals.Detail.noWaitingBooth)
-//                                        .foregroundStyle(.white)
-//                                        .font(.system(size: 14))
-//                                        .bold()
-//                                }
-//                            } else {
-//                                Text(StringLiterals.Detail.noWaitingBooth)
-                            Text("웨이팅 신청")
-                                    .foregroundStyle(.white)
-                                    .font(.system(size: 14))
-                                    .bold()
-                            //}
+                            if let selectedBooth = viewModel.boothModel.selectedBooth {
+                                if selectedBooth.waitingEnabled {
+                                    Text("웨이팅 하기")
+                                        .font(.pretendard(weight: .p7, size: 14))
+                                        .foregroundStyle(.white)
+                                } else {
+                                    Text(StringLiterals.Detail.noWaitingBooth)
+                                        .font(.pretendard(weight: .p7, size: 14))
+                                        .foregroundStyle(.white)
+                                }
+                            } else {
+                                if !isReloadButtonPresent {
+                                    ProgressView()
+                                } else {
+                                    Text(StringLiterals.Detail.noWaitingBooth)
+                                        .foregroundStyle(.white)
+                                        .font(.system(size: 14))
+                                        .bold()
+                                }
+                            }
                         }
                 }
-                // .disabled(true)
+                // .disabled(viewModel.boothModel.selectedBooth?.waitingEnabled == false || viewModel.boothModel.selectedBooth?.waitingEnabled == nil)
                 
                 Spacer()
                     .frame(width: 20)

--- a/unifest-ios/Views/Detail/BoothInfoView.swift
+++ b/unifest-ios/Views/Detail/BoothInfoView.swift
@@ -186,10 +186,10 @@ struct BoothInfoView: View {
                                 .foregroundStyle(.grey600)
                                 .padding(.leading, -1)
                                 .rotationEffect(isOperatingHoursExpanded ? .degrees(180) : .zero)
-                            
-                            Spacer()
                         }
                     }
+                    
+                    Spacer()
                 }
                 .padding(.horizontal, 14)
                 

--- a/unifest-ios/Views/Detail/BoothInfoView.swift
+++ b/unifest-ios/Views/Detail/BoothInfoView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct BoothInfoView: View {
     @ObservedObject var viewModel: RootViewModel
     @State private var isMapViewPresented: Bool = false
+    @State private var isOperatingHoursExpanded: Bool = false
     @Binding var selectedBoothHours: Int
     @Binding var isReloadButtonPresent: Bool
     @Environment(\.dismiss) var dismiss
@@ -142,7 +143,7 @@ struct BoothInfoView: View {
                             Text(viewModel.boothModel.selectedBooth?.warning ?? "")
                                 .font(.pretendard(weight: .p6, size: 11))
                                 .foregroundStyle(.primary500)
-                                // .lineLimit(3)
+                            // .lineLimit(3)
                         }
                     }
                 }
@@ -165,11 +166,79 @@ struct BoothInfoView: View {
                 }
                 
                 HStack {
+                    Button {
+                        withAnimation {
+                            isOperatingHoursExpanded.toggle()
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: "clock")
+                                .foregroundStyle(.ufBluegreen)
+                                .font(.system(size: 15))
+                            
+                            Text("운영중")
+                                .font(.pretendard(weight: .p5, size: 13))
+                                .foregroundStyle(.grey900)
+                            
+                            Image(systemName: "chevron.down")
+                                .resizable()
+                                .frame(width: 10, height: 8)
+                                .foregroundStyle(.grey600)
+                                .padding(.leading, -1)
+                                .rotationEffect(isOperatingHoursExpanded ? .degrees(180) : .zero)
+                            
+                            Spacer()
+                        }
+                    }
+                }
+                .padding(.horizontal, 14)
+                
+                if isOperatingHoursExpanded {
+                    VStack {
+                        HStack {
+                            Text("Open Time: ")
+                                .padding(.trailing, -5)
+                            
+                            if let openTime = viewModel.boothModel.selectedBooth?.openTime {
+                                let timeString = formatTime(openTime)
+                                Text(timeString)
+                            } else {
+                                let timeString = formatTime("10:00:00")
+                                Text(timeString)
+                                // Text("등록된 정보가 없습니다")
+                            }
+                            
+                            Spacer()
+                        }
+                        .padding(.bottom, 2)
+                        
+                        HStack {
+                            Text("Close Time: ")
+                                .padding(.trailing, -5)
+                            
+                            if let closeTime = viewModel.boothModel.selectedBooth?.closeTime {
+                                let timeString = formatTime(closeTime)
+                                Text(timeString)
+                            } else {
+                                Text("등록된 정보가 없습니다")
+                            }
+                            
+                            Spacer()
+                        }
+                    }
+                    .font(.pretendard(weight: .p5, size: 13))
+                    .foregroundStyle(.grey700)
+                    .padding(.leading, 40)
+                    .padding(.top, -1)
+                    .padding(.bottom, 5)
+                }
+                
+                HStack {
                     Image(.marker)
                     
-                    MarqueeText(text: viewModel.boothModel.selectedBooth?.location ?? "", font: .systemFont(ofSize: 13), leftFade: 10, rightFade: 10, startDelay: 2, alignment: .leading)
-                    // Text(viewModel.boothModel.selectedBooth?.location ?? "")
-                    // .font(.system(size: 13))
+                    Text(viewModel.boothModel.selectedBooth?.location ?? "")
+                        .font(.pretendard(weight: .p5, size: 13))
+                        .foregroundStyle(.grey900)
                     
                     Spacer()
                 }
@@ -213,6 +282,24 @@ struct BoothInfoView: View {
                     }
             }
         })
+    }
+    
+    func formatTime(_ time: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm:ss"
+        
+        if let date = dateFormatter.date(from: time) {
+            let calendar = Calendar.current
+            let hour = calendar.component(.hour, from: date)
+            let minute = calendar.component(.minute, from: date)
+            return String(format: "%02d시 %02d분", hour, minute) // 00을 포함한 형식으로 출력
+//            // OO:OO 형식으로 format하는 코드
+//            dateFormatter.dateFormat = "HH:mm"
+//            let formattedTime = dateFormatter.string(from: date)
+//            return formattedTime
+        } else {
+            return ""
+        }
     }
 }
 

--- a/unifest-ios/Views/Detail/BoothInfoView.swift
+++ b/unifest-ios/Views/Detail/BoothInfoView.swift
@@ -182,7 +182,7 @@ struct BoothInfoView: View {
                             
                             Image(systemName: "chevron.down")
                                 .resizable()
-                                .frame(width: 10, height: 8)
+                                .frame(width: 10, height: 6)
                                 .foregroundStyle(.grey600)
                                 .padding(.leading, -1)
                                 .rotationEffect(isOperatingHoursExpanded ? .degrees(180) : .zero)

--- a/unifest-ios/Views/Detail/BoothMenuView.swift
+++ b/unifest-ios/Views/Detail/BoothMenuView.swift
@@ -51,7 +51,14 @@ struct BoothMenuView: View {
                     } else {
                         VStack(spacing: 10) {
                             ForEach(boothMenu, id: \.self) { menu in
-                                MenuBarView(imageURL: menu.imgUrl ?? "", name: menu.name ?? "", price: menu.price ?? 0, isMenuImagePresented: $isMenuImagePresented, selectedMenu: $selectedMenu)
+                                MenuBarView(
+                                    imageURL: menu.imgUrl ?? "",
+                                    name: menu.name ?? "",
+                                    price: menu.price ?? 0,
+                                    // menuStatus: menu.menuStatus,
+                                    menuStatus: "UNDER_50",
+                                    isMenuImagePresented: $isMenuImagePresented,
+                                    selectedMenu: $selectedMenu)
                             }
                         }
                         .padding(.horizontal)

--- a/unifest-ios/Views/Detail/MenuBarView.swift
+++ b/unifest-ios/Views/Detail/MenuBarView.swift
@@ -13,9 +13,17 @@ struct MenuBarView: View {
     let imageURL: String
     let name: String
     let price: Int
+    let menuStatus: String?
     @Binding var isMenuImagePresented: Bool
     @Binding var selectedMenu: SelectedMenuInfo
     @Environment(\.colorScheme) var colorScheme
+    
+    enum menuState: String {
+        case ENOUGH = ""
+        case UNDER_50 = "50개 미만"
+        case UNDER_10 = "10개 미만"
+        case SOLD_OUT = "품절"
+    }
     
     var body: some View {
         HStack {
@@ -62,6 +70,49 @@ struct MenuBarView: View {
                         .font(.pretendard(weight: .p6, size: 16))
                         .foregroundStyle(.grey900)
                 }
+                
+                if let menuStatus = menuStatus {
+                    if menuStatus == "UNDER_50" {
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(Color.grey200)
+                            .frame(width: 92, height: 21)
+                            .overlay {
+                                HStack {
+                                    Text("50개 미만")
+                                        .font(.pretendard(weight: .p6, size: 11))
+                                        .foregroundStyle(.grey600)
+                                    Text(" 남음")
+                                        .font(.pretendard(weight: .p4, size: 11))
+                                        .foregroundStyle(.grey600)
+                                        .padding(.leading, -8)
+                                }
+                            }
+                    } else if menuStatus == "UNDER_10" {
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(Color.grey200)
+                            .frame(width: 92, height: 21)
+                            .overlay {
+                                HStack {
+                                    Text("10개 미만")
+                                        .font(.pretendard(weight: .p6, size: 11))
+                                        .foregroundStyle(.grey600)
+                                    Text(" 남음")
+                                        .font(.pretendard(weight: .p4, size: 11))
+                                        .foregroundStyle(.grey600)
+                                        .padding(.leading, -8)
+                                }
+                            }
+                    } else if menuStatus == "SOLD_OUT" {
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(Color.grey200)
+                            .frame(width: 39, height: 21)
+                            .overlay {
+                                Text("품절")
+                                    .font(.pretendard(weight: .p6, size: 11))
+                                    .foregroundStyle(.ufRed)
+                            }
+                    }
+                }
             }
             
             Spacer()
@@ -79,4 +130,8 @@ struct MenuBarView: View {
                 return "\(price)"
             }
         }
+}
+
+#Preview {
+    MenuBarView(imageURL: "", name: "모둠 사시미", price: 45_000, menuStatus: "UNDER_50", isMenuImagePresented: .constant(false), selectedMenu: .constant(SelectedMenuInfo()))
 }

--- a/unifest-ios/Views/Map/MapPageView.swift
+++ b/unifest-ios/Views/Map/MapPageView.swift
@@ -26,157 +26,169 @@ struct MapPageView: View {
     @State private var searchText: String = ""
     
     var body: some View {
-        ZStack {
-            VStack {
-                Spacer()
-                
-                if #available(iOS 17, *) {
-                    MapViewiOS17(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
-                } else {
-                    MapViewiOS16(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
-                }
-            }
-            
-            VStack {
-                // MapPageHeaderView(searchText: $searchText, isTagSelected: $isTagSelected, isSearchSchoolViewPresented: $isSearchSchoolViewPresented, isPopularBoothPresented: $isPopularBoothPresented)
-                MapPageHeaderView(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
-                    .background(.ufBackground)
-                    .clipShape(
-                        .rect(
-                            topLeadingRadius: 0,
-                            bottomLeadingRadius: 23,
-                            bottomTrailingRadius: 23,
-                            topTrailingRadius: 0
-                        )
-                    )
-                
-                Spacer()
-                
-                // 지도에서 annotation을 탭했을 때 보이는 X버튼
-                if mapViewModel.isBoothListPresented {
-                    Button {
-                        DispatchQueue.main.async {
-                            withAnimation(.spring) {
-                                mapViewModel.isBoothListPresented = false
-                            }
-                        }
-                        mapViewModel.setSelectedAnnotationID(-1)
-                        viewModel.boothModel.updateMapSelectedBoothList([])
-                    } label: {
-                        Text("").roundedButton(background: .ufBackground, strokeColor: .primary500, height: 36, cornerRadius: 18)
-                            .frame(width: 36)
-                            .overlay {
-                                Image(systemName: "xmark")
-                                    .foregroundColor(.primary500)
-                            }
-                        // Image(.popCloseButton)
+        GeometryReader { geometry in
+            ZStack {
+                VStack {
+                    Spacer()
+                    
+                    if #available(iOS 17, *) {
+                        MapViewiOS17(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
+                    } else {
+                        MapViewiOS16(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
                     }
                 }
                 
-                if !viewModel.boothModel.top5booths.isEmpty && searchText.isEmpty && !mapViewModel.isBoothListPresented {
-                    VStack {
+                VStack {
+                    // MapPageHeaderView(searchText: $searchText, isTagSelected: $isTagSelected, isSearchSchoolViewPresented: $isSearchSchoolViewPresented, isPopularBoothPresented: $isPopularBoothPresented)
+                    MapPageHeaderView(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
+                        .background(.ufBackground)
+                        .clipShape(
+                            .rect(
+                                topLeadingRadius: 0,
+                                bottomLeadingRadius: 23,
+                                bottomTrailingRadius: 23,
+                                topTrailingRadius: 0
+                            )
+                        )
+                    
+                    Spacer()
+                    
+                    // 지도에서 annotation을 탭했을 때 보이는 X버튼
+                    if mapViewModel.isBoothListPresented {
                         Button {
-                            if mapViewModel.isPopularBoothPresented {
-                                // on -> off
-                                GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLOSE_FABOR_BOOTH)
-                                DispatchQueue.main.async {
-                                    withAnimation {
-                                        mapViewModel.isPopularBoothPresented = false
-                                    }
+                            DispatchQueue.main.async {
+                                withAnimation(.spring) {
+                                    mapViewModel.isBoothListPresented = false
                                 }
-                            } else {
-                                // off -> on
-                                GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_OPEN_FABOR_BOOTH)
-                                if mapViewModel.isBoothListPresented {
+                            }
+                            mapViewModel.setSelectedAnnotationID(-1)
+                            viewModel.boothModel.updateMapSelectedBoothList([])
+                        } label: {
+                            Text("").roundedButton(background: .ufBackground, strokeColor: .primary500, height: 36, cornerRadius: 18)
+                                .frame(width: 36)
+                                .overlay {
+                                    Image(systemName: "xmark")
+                                        .foregroundColor(.primary500)
+                                }
+                            // Image(.popCloseButton)
+                        }
+                    }
+                    
+                    if !viewModel.boothModel.top5booths.isEmpty && searchText.isEmpty && !mapViewModel.isBoothListPresented {
+                        VStack {
+                            Button {
+                                if mapViewModel.isPopularBoothPresented {
+                                    // on -> off
+                                    GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLOSE_FABOR_BOOTH)
                                     DispatchQueue.main.async {
                                         withAnimation {
-                                            mapViewModel.isBoothListPresented = false
+                                            mapViewModel.isPopularBoothPresented = false
+                                        }
+                                    }
+                                } else {
+                                    // off -> on
+                                    GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_OPEN_FABOR_BOOTH)
+                                    if mapViewModel.isBoothListPresented {
+                                        DispatchQueue.main.async {
+                                            withAnimation {
+                                                mapViewModel.isBoothListPresented = false
+                                            }
+                                        }
+                                    }
+                                    DispatchQueue.main.async {
+                                        withAnimation {
+                                            mapViewModel.isPopularBoothPresented = true
                                         }
                                     }
                                 }
-                                DispatchQueue.main.async {
-                                    withAnimation {
-                                        mapViewModel.isPopularBoothPresented = true
+                            } label: {
+                                Text("")
+                                    .roundedButton(background: .ufNetworkErrorBackground, strokeColor: .primary500, height: 36, cornerRadius: 39)
+                                    .frame(width: 120)
+                                // Image(.popBoothButton)
+                                    .overlay {
+                                        HStack {
+                                            Text(StringLiterals.Map.favoriteBoothTitle)
+                                                .font(.pretendard(weight: .p7, size: 13))
+                                                .foregroundStyle(.primary500)
+                                            Image(.upPinkArrow)
+                                                .rotationEffect(mapViewModel.isPopularBoothPresented ? .degrees(180) : .degrees(0))
+                                        }
                                     }
-                                }
-                            }
-                        } label: {
-                            Text("")
-                                .roundedButton(background: .ufNetworkErrorBackground, strokeColor: .primary500, height: 36, cornerRadius: 39)
-                                .frame(width: 120)
-                            // Image(.popBoothButton)
-                                .overlay {
-                                    HStack {
-                                        Text(StringLiterals.Map.favoriteBoothTitle)
-                                            .font(.pretendard(weight: .p7, size: 13))
-                                            .foregroundStyle(.primary500)
-                                        Image(.upPinkArrow)
-                                            .rotationEffect(mapViewModel.isPopularBoothPresented ? .degrees(180) : .degrees(0))
-                                    }
-                                }
-                        }
-                        
-                        if mapViewModel.isPopularBoothPresented == false {
-                            Spacer()
-                                .frame(height: 95)
-                        }
-                    }
-                }
-                
-                // isPopularBoothPresented: '인기 부스' 버튼을 탭할 때 true/false
-                // isBoothListPresented: map의 annotation을 탭했을 때 true/false
-                if mapViewModel.isPopularBoothPresented || mapViewModel.isBoothListPresented {
-                    if mapViewModel.isPopularBoothPresented {
-                        VStack {
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack {
-                                    ForEach(Array(viewModel.boothModel.top5booths.enumerated()), id: \.1) { index, topBooth in
-                                        BoothBox(rank: index, title: topBooth.name, description: topBooth.description, position: topBooth.location, imageURL: topBooth.thumbnail)
-                                            .onTapGesture {
-                                                GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLOSE_FABOR_BOOTH, params: ["boothID": topBooth.id])
-                                                viewModel.boothModel.loadBoothDetail(topBooth.id)
-                                                isBoothDetailViewPresented = true
-                                            }
-                                    }
-                                }
-                                .padding(.horizontal, 35)
-                                .frame(maxWidth: .infinity)
                             }
                             
-                            Spacer()
-                                .frame(height: 93)
+                            if mapViewModel.isPopularBoothPresented == false {
+                                Spacer()
+                                    .frame(height: 95)
+                            }
                         }
-                        
-                    } else {
-                        if viewModel.boothModel.mapSelectedBoothList.isEmpty {
-                            //
-                        } else {
+                    }
+                    
+                    // isPopularBoothPresented: '인기 부스' 버튼을 탭할 때 true/false
+                    // isBoothListPresented: map의 annotation을 탭했을 때 true/false
+                    if mapViewModel.isPopularBoothPresented || mapViewModel.isBoothListPresented {
+                        if mapViewModel.isPopularBoothPresented {
                             VStack {
-                                ForEach(viewModel.boothModel.mapSelectedBoothList, id: \.self) { booth in
-                                    BoothBox(rank: -1, title: booth.name, description: booth.description, position: booth.location, imageURL: booth.thumbnail)
-                                        .onTapGesture {
-                                            GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLICK_BOOTH_ROW, params: ["boothID": booth.id])
-                                            viewModel.boothModel.loadBoothDetail(booth.id)
-                                            tappedBoothId = booth.id
-                                            isBoothDetailViewPresented = true
+                                ScrollView(.horizontal, showsIndicators: false) {
+                                    HStack {
+                                        ForEach(Array(viewModel.boothModel.top5booths.enumerated()), id: \.1) { index, topBooth in
+                                            BoothBox(rank: index, title: topBooth.name, description: topBooth.description, position: topBooth.location, imageURL: topBooth.thumbnail)
+                                                .onTapGesture {
+                                                    GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLOSE_FABOR_BOOTH, params: ["boothID": topBooth.id])
+                                                    viewModel.boothModel.loadBoothDetail(topBooth.id)
+                                                    isBoothDetailViewPresented = true
+                                                }
                                         }
+                                    }
+                                    .padding(.horizontal, (geometry.size.width - 306) / 2) // (화면너비-BoothBox너비)/2를 padding으로 줌
+                                    .frame(minWidth: geometry.size.width)
                                 }
                                 
                                 Spacer()
-                                    .frame(height: 93) // VStack
+                                    .frame(height: 93)
+                            }
+                            
+                        } else {
+                            if viewModel.boothModel.mapSelectedBoothList.isEmpty {
+                                //
+                            } else {
+                                VStack {
+                                    ScrollView(.horizontal, showsIndicators: false) {
+                                        HStack {
+                                            Spacer()
+                                            
+                                            ForEach(viewModel.boothModel.mapSelectedBoothList, id: \.self) { booth in
+                                                BoothBox(rank: -1, title: booth.name, description: booth.description, position: booth.location, imageURL: booth.thumbnail)
+                                                    .onTapGesture {
+                                                        GATracking.sendLogEvent(GATracking.LogEventType.MapView.MAP_CLICK_BOOTH_ROW, params: ["boothID": booth.id])
+                                                        viewModel.boothModel.loadBoothDetail(booth.id)
+                                                        tappedBoothId = booth.id
+                                                        isBoothDetailViewPresented = true
+                                                    }
+                                            }
+                                            
+                                            Spacer()
+                                        }
+                                        .padding(.horizontal, (geometry.size.width - 306) / 2) // (화면너비-BoothBox너비)/2를 padding으로 줌
+                                        .frame(minWidth: geometry.size.width)
+                                    }
+                                    
+                                    Spacer()
+                                        .frame(height: 93) // VStack
+                                }
                             }
                         }
                     }
                 }
             }
+            .ignoresSafeArea()
+            .sheet(isPresented: $isBoothDetailViewPresented) {
+                BoothDetailView(viewModel: viewModel, currentBoothId: tappedBoothId)
+                    .presentationDragIndicator(.visible)
+            }
+            .onAppear {
+                viewModel.boothModel.loadTop5Booth()
         }
-        .ignoresSafeArea()
-        .sheet(isPresented: $isBoothDetailViewPresented) {
-            BoothDetailView(viewModel: viewModel, currentBoothId: tappedBoothId)
-                .presentationDragIndicator(.visible)
-        }
-        .onAppear {
-            viewModel.boothModel.loadTop5Booth()
         }
     }
 }

--- a/unifest-ios/Views/Menu/MenuView.swift
+++ b/unifest-ios/Views/Menu/MenuView.swift
@@ -18,7 +18,9 @@ struct MenuView: View {
     @State private var isDetailViewPresented: Bool = false
     @State private var randomLikeList: [Int] = []
     
-    @State private var isPermissionAlertPresented: Bool = false
+    // 권한 수정
+    @State private var isLocationPermissionAlertPresented: Bool = false
+    @State private var isCameraPermissionAlertPresented: Bool = false
     
     // 메일
     @State private var isErrorDeclarationModalPresented: Bool = false
@@ -431,7 +433,7 @@ struct MenuView: View {
                 
                 // 권한 수정
                 Button {
-                    isPermissionAlertPresented = true
+                    isLocationPermissionAlertPresented = true
                     GATracking.sendLogEvent(GATracking.LogEventType.MenuView.MENU_OPEN_SETTING)
                 } label: {
                     HStack {
@@ -443,6 +445,30 @@ struct MenuView: View {
                             .padding(.trailing, 8)
                         
                         Text(StringLiterals.Menu.locationAuthText)
+                            .font(.pretendard(weight: .p5, size: 15))
+                            .foregroundStyle(.grey900)
+                        
+                        Spacer()
+                    }
+                    .frame(height: 60)
+                    .padding(.horizontal)
+                }
+                
+                Divider()
+                
+                Button {
+                    isCameraPermissionAlertPresented = true
+                    // GATracking.sendLogEvent(GATracking.LogEventType.MenuView.MENU_OPEN_SETTING) // 카메라 GATracking 추가하고 코드 수정하기
+                } label: {
+                    HStack {
+                        Image(systemName: "camera.circle")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.darkGray)
+                            .padding(.trailing, 8)
+                        
+                        Text(StringLiterals.Menu.cameraAuthText)
                             .font(.pretendard(weight: .p5, size: 15))
                             .foregroundStyle(.grey900)
                         
@@ -647,7 +673,7 @@ struct MenuView: View {
                 }
         }
         // 권한 허가 수정 안내 모달
-        .alert("권한 허가 수정 안내", isPresented: $isPermissionAlertPresented, actions: {
+        .alert("위치 권한 허가 수정 안내", isPresented: $isLocationPermissionAlertPresented, actions: {
             Button("설정 앱으로 이동할래요", role: .cancel) {
                 guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
                 
@@ -656,12 +682,24 @@ struct MenuView: View {
                 }
                 
             }
-            Button("알겠어요", role: nil) {
-                
-            }
+            
+            Button("알겠어요", role: nil) { }
         }, message: {
             Text("권한 허가 수정은 Apple 정책 상 직접 iPhone 설정 - 유니페스 에서 권한을 수정할 수 있어요.")
         })
+        .alert("카메라 권한 허가 수정 안내", isPresented: $isCameraPermissionAlertPresented) {
+            Button("설정 앱으로 이동할래요", role: .cancel) {
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            
+            Button("알겠어요", role: nil) { }
+        } message: {
+            Text("권한 허가 수정은 Apple 정책 상 직접 iPhone 설정 - 유니페스 에서 권한을 수정할 수 있어요.")
+        }
         // 기능 오류 신고 모달
         .alert("피드백 안내", isPresented: $isErrorDeclarationModalPresented, actions: {
             Button("메일을 작성할래요", role: nil) {


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue

<br/>

### 🌟Motivation

<br/>

### 🌟Key Changes

[Design]

* 메뉴 수량을 확인할 수 있는 뷰 추가

* 부스 운영시간을 확인하는 뷰 추가

[Fix]

* Clustering을 적용하고 지도에서 Clustering된 map annotation을 탭했을 때 일부 BoothBox만 보이는 오류 수정

* BoothBox가 모든 디바이스에서 화면 정중앙에 위치할 수 있도록 padding값이 화면 너비에 따라 동적으로 조절되도록 수정

[Feat]

* 메뉴 탭에 카메라 권한 수정 옵션 추가

* 부스의 웨이팅 지원 여부에 따라 '웨이팅 하기' 버튼을 활성화/비활성화하는 코드 추가

### 🌟Simulation

<img src="https://github.com/user-attachments/assets/f2c97b1b-c2a1-4af1-bfc7-332beec69f27" width="200" />

<img src="https://github.com/user-attachments/assets/ee6971e2-6b2c-4ff7-aa42-1f6d344ae5e6" width="200" />


### 🌟To Reviewer

<br/>
* Clustering을 적용하고 지도에서 Clustering된 map annotation을 탭했을 때 일부 BoothBox만 보이는 오류 수정 - 기존 코드에서 cluster옵션을 선택한 상태로 cluster된 annotation을 선택하면 BoothBox가 VStack 내의 ForEach구문에서 나타나 모든 BoothBox를 확인할 수 없는 문제가 있었고, VStack 대신 Horizontal Scrollview를 사용해 문제를 해결했습니다

### 🌟Reference

<br/>
