### PR TITLE
[Refactor] 관심축제를 추가/삭제하는 화면과 관련 기능 구현 및 리팩토링 진행

### DIFF
--- a/unifest-ios.xcodeproj/project.pbxproj
+++ b/unifest-ios.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		0CB2170F2BF23F270003338B /* festivalTest.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CB2170E2BF23F270003338B /* festivalTest.json */; };
 		0CBB058B2BB074ED00EB56BE /* MapPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB05832BB074ED00EB56BE /* MapPageView.swift */; };
 		0CBB058C2BB074ED00EB56BE /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB05842BB074ED00EB56BE /* MapView.swift */; };
-		0CBB058D2BB074ED00EB56BE /* SearchSchoolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB05852BB074ED00EB56BE /* SearchSchoolView.swift */; };
+		0CBB058D2BB074ED00EB56BE /* EditFavoriteFestivalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB05852BB074ED00EB56BE /* EditFavoriteFestivalView.swift */; };
 		0CC40F422BF9276B002759DF /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC40F412BF9276B002759DF /* View+.swift */; };
 		0CC40F442BF92A6B002759DF /* MarqueeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC40F432BF92A6B002759DF /* MarqueeText.swift */; };
 		0CDB46D52BB1DC8D00C34AED /* BoothDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDB46D42BB1DC8D00C34AED /* BoothDetailView.swift */; };
@@ -134,7 +134,7 @@
 		0CB2170E2BF23F270003338B /* festivalTest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = festivalTest.json; sourceTree = "<group>"; };
 		0CBB05832BB074ED00EB56BE /* MapPageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapPageView.swift; sourceTree = "<group>"; };
 		0CBB05842BB074ED00EB56BE /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
-		0CBB05852BB074ED00EB56BE /* SearchSchoolView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSchoolView.swift; sourceTree = "<group>"; };
+		0CBB05852BB074ED00EB56BE /* EditFavoriteFestivalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditFavoriteFestivalView.swift; sourceTree = "<group>"; };
 		0CC40F412BF9276B002759DF /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		0CC40F432BF92A6B002759DF /* MarqueeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeText.swift; sourceTree = "<group>"; };
 		0CDB46D42BB1DC8D00C34AED /* BoothDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoothDetailView.swift; sourceTree = "<group>"; };
@@ -392,7 +392,7 @@
 				0CBB05832BB074ED00EB56BE /* MapPageView.swift */,
 				F87DCA522C32DBB00038F845 /* MapPageHeaderView.swift */,
 				0CBB05842BB074ED00EB56BE /* MapView.swift */,
-				0CBB05852BB074ED00EB56BE /* SearchSchoolView.swift */,
+				0CBB05852BB074ED00EB56BE /* EditFavoriteFestivalView.swift */,
 				F815E13F2C330064002C61DB /* LongSchoolBoxView.swift */,
 				0CDB46D62BB1E7F400C34AED /* OneMapView.swift */,
 				0CAA190D2C31A63C0029312E /* SchoolBoxView.swift */,
@@ -675,7 +675,7 @@
 				0CBB058B2BB074ED00EB56BE /* MapPageView.swift in Sources */,
 				F87DCA532C32DBB00038F845 /* MapPageHeaderView.swift in Sources */,
 				0C72FAAA2BFA3C4C00782B61 /* ThemeManager.swift in Sources */,
-				0CBB058D2BB074ED00EB56BE /* SearchSchoolView.swift in Sources */,
+				0CBB058D2BB074ED00EB56BE /* EditFavoriteFestivalView.swift in Sources */,
 				0C9D0A6D2BA1A45F00156763 /* MapViewModel.swift in Sources */,
 				F896A2932CCBACD50093621F /* BoothNoshowDialogView.swift in Sources */,
 				0C7A9CA62BF3E91100F639BA /* GATracker.swift in Sources */,

--- a/unifest-ios/Data/FestivalData.swift
+++ b/unifest-ios/Data/FestivalData.swift
@@ -114,6 +114,7 @@ class FestivalModel: ObservableObject {
     init() {
         loadStoreListData {
             print("data is all loaded")
+            print(self.festivals)
         }
     }
     
@@ -137,7 +138,7 @@ class FestivalModel: ObservableObject {
         }
     }
     
-    func searchFestival(by keyword: String) {
+    func filterFestivals(byKeyword keyword: String) {
         guard !keyword.trimmingCharacters(in: .whitespaces).isEmpty else {
                 festivalSearchResult = []
                 return
@@ -146,6 +147,16 @@ class FestivalModel: ObservableObject {
         // 영어일 경우 대소문자 무시하고 검색
         festivalSearchResult = festivals.filter { festival in
             festival.festivalName.localizedCaseInsensitiveContains(keyword) || festival.schoolName.localizedCaseInsensitiveContains(keyword)
+        }
+    }
+    
+    func filterFestivals(byRegion region: String) {
+        if region == "전체" {
+            festivalSearchResult = festivals
+        } else {
+            festivalSearchResult = festivals.filter { festival in
+                festival.region.contains(region)
+            }
         }
     }
     

--- a/unifest-ios/Data/FestivalData.swift
+++ b/unifest-ios/Data/FestivalData.swift
@@ -154,36 +154,39 @@ class FestivalModel: ObservableObject {
         }
     }
     
+    // 사용자가 선택한 날짜에 열리는 축제의 개수 반환
     func isFestival(year: Int, month: Int, day: Int) -> Int {
         var count: Int = 0
         
         for festival in festivals {
-            // Convert festival beginDate and endDate strings to Date objects
+            // dateFormatter를 연-월-일로 설정
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd"
             
+            // 축제 첫째날을 beginDate, 마지막날을 endDate에 저장
             guard let beginDate = dateFormatter.date(from: festival.beginDate),
                   let endDate = dateFormatter.date(from: festival.endDate) else {
                 continue // Skip iteration if date conversion fails
             }
             
-            // Create date components for the given month and day
+            // 파라미터로 전달된 선택된 날짜를 components에 저장
             var components = DateComponents()
             components.year = year
             components.month = month
             components.day = day
             
-            // Create date object for the given month and day
+            // components로 date인스턴스 생성, currentDate에 저장
             guard let currentDate = Calendar.current.date(from: components) else {
                 continue // Skip iteration if date creation fails
             }
             
-            // Check if currentDate falls within the range of festival dates
+            // currentDate가 축제 첫째날~마지막날 사이에 있다면 count값 1 증가
             if (currentDate >= beginDate) && (currentDate <= endDate) {
                 count += 1
             }
         }
         
+        // api에서 받아온 모든 대학 축제 배열에서, 사용자가 선택한 날짜에 열리는 축제의 개수 반환
         return count
     }
     

--- a/unifest-ios/Networking/APIManager.swift
+++ b/unifest-ios/Networking/APIManager.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 final class APIManager: ObservableObject {
     
-    static let shared = APIManager(serverType: .prod)
+    static let shared = APIManager(serverType: .dev)
     private var cancellables = Set<AnyCancellable>()
     
     // API 서버 종류별 address

--- a/unifest-ios/Text/StringLiterals.swift
+++ b/unifest-ios/Text/StringLiterals.swift
@@ -72,7 +72,7 @@ enum StringLiterals {
         static let title = "메뉴"
         static let LikedSchoolTitle = "나의 관심축제"
         static let LikedBoothTitle = "관심부스"
-        static let more = "더보기"
+        static let more = "더보기 >"
         static let noLikedBoothTitle = "관심부스 없음"
         static let noLikedBoothMessage = "지도에서 관심있는 부스를 추가해주세요"
         static let askTitle = "이용문의 (카카오톡 채널)"

--- a/unifest-ios/Views/Detail/BoothFooterView.swift
+++ b/unifest-ios/Views/Detail/BoothFooterView.swift
@@ -22,9 +22,6 @@ struct BoothFooterView: View {
                 let screenWidth = geometry.size.width
                 
                 HStack {
-                    //                Spacer()
-                    //                    .frame(width: 10)
-                    
                     // 사용자가 좋아요 처리한 부스는 서버가 아니라 로컬(UserDefaults)에 저장함
                     // 좋아요를 누르거나 해제하면 UserDefaults에서 해당 부스를 추가하거나 해제하고, 좋아요 수를 +-시키는 api를 호출함
                     VStack {

--- a/unifest-ios/Views/Home/FestivalInfoView.swift
+++ b/unifest-ios/Views/Home/FestivalInfoView.swift
@@ -45,6 +45,7 @@ struct FestivalInfoView: View {
                 Spacer()
             }
             .padding(.horizontal)
+            .padding(.top, 18)
             
             VStack {
                 if (viewModel.festivalModel.isFestival(year: currentYear, month: selectedMonth, day: selectedDay) == 0) {
@@ -135,6 +136,7 @@ struct FestivalInfoView: View {
             }
             .padding(.horizontal)
             .padding(.bottom, 4)
+            .padding(.top, -5)
             
             VStack(spacing: 8) {
                 if viewModel.festivalModel.getFestivalAfter(year: currentYear, month: currentMonth, day: currentDay, maxLength: maxLength).isEmpty {

--- a/unifest-ios/Views/Home/HomeView.swift
+++ b/unifest-ios/Views/Home/HomeView.swift
@@ -259,6 +259,7 @@ struct HomeView: View {
                 selectedMonth: $selectedMonth,
                 selectedDay: $selectedDay
             )
+            .padding(.top, -17)
         }
         .background(.ufBackground)
     }

--- a/unifest-ios/Views/Intro/IntroView.swift
+++ b/unifest-ios/Views/Intro/IntroView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct IntroView: View {
     @ObservedObject var viewModel: RootViewModel
     @Environment(\.dismiss) var dismiss
+    @Environment(\.colorScheme) var colorScheme
     @State private var likedList: [Int] = []
     @State private var searchText: String = ""
     @State private var count: Int = 0
@@ -22,7 +23,7 @@ struct IntroView: View {
         VStack(alignment: .center) {
             VStack {
                 Spacer()
-                    .frame(height: 78)
+                    .frame(height: 40)
                 
                 Text(StringLiterals.Intro.infoTitle)
                     .font(.pretendard(weight: .p6, size: 18))
@@ -34,7 +35,7 @@ struct IntroView: View {
                     .foregroundStyle(.grey600)
                 
                 Spacer()
-                    .frame(height: 52)
+                    .frame(height: 32)
                 
                 Image(.searchBox)
                     .overlay {
@@ -67,7 +68,7 @@ struct IntroView: View {
                     .padding(.bottom)
                 
                 Spacer()
-                    .frame(height: 18)
+                    .frame(height: 5)
                 
                 HStack {
                     Text(StringLiterals.Intro.myFestivalTitle)
@@ -108,13 +109,13 @@ struct IntroView: View {
                  */
                 
                 Rectangle()
-                    .fill(.grey100)
+                    .fill(colorScheme == .light ? .grey100 : .grey200)
                     .frame(height: 7)
                     .padding(.top, 20)
                 
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 20) {
-                        ForEach(0 ..< regions.count) { index in
+                        ForEach(regions.indices, id: \.self) { index in
                             Button {
                                 withAnimation(.spring) {
                                     regionIndex = index
@@ -128,23 +129,12 @@ struct IntroView: View {
                         }
                     }
                     .padding(.horizontal)
+                    .padding(.vertical, 10)
                 }
-                .padding(.vertical, 10)
                 
-                Divider()
-                    .frame(height: 1.5)
-                    .background(.grey100)
-                
-                HStack {
-                    Text("총 \(viewModel.festivalModel.festivalSearchResult.count)개")
-                        .font(.pretendard(weight: .p5, size: 12))
-                        .foregroundStyle(.grey900)
-                    
-                    Spacer()
-                }
-                .padding(.horizontal)
-                .padding(.vertical, 5)
-                
+                Rectangle()
+                    .fill(.grey300)
+                    .frame(height: 1)
                 
                 if viewModel.festivalModel.festivalSearchResult.isEmpty {
                     VStack {
@@ -156,20 +146,34 @@ struct IntroView: View {
                     }
                 } else {
                     ScrollView {
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3), spacing: 10) {
-                            ForEach(viewModel.festivalModel.festivalSearchResult, id: \.festivalId) { festival in
-                                SchoolBoxView(
-                                    isSelected: .constant(false),
-                                    schoolImageURL: festival.thumbnail,
-                                    schoolName: festival.schoolName,
-                                    festivalName: festival.festivalName,
-                                    startDate: festival.beginDate,
-                                    endDate: festival.endDate
-                                )
+                        VStack {
+                            HStack {
+                                Text("총 \(viewModel.festivalModel.festivalSearchResult.count)개")
+                                    .font(.pretendard(weight: .p5, size: 12))
+                                    .foregroundStyle(.grey900)
+                                
+                                Spacer()
                             }
+                            .padding(.horizontal)
+                            .padding(.vertical, 5)
+                            .padding(.top, 5)
+
+                            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3), spacing: 10) {
+                                ForEach(viewModel.festivalModel.festivalSearchResult, id: \.festivalId) { festival in
+                                    SchoolBoxView(
+                                        isSelected: .constant(false),
+                                        schoolImageURL: festival.thumbnail,
+                                        schoolName: festival.schoolName,
+                                        festivalName: festival.festivalName,
+                                        startDate: festival.beginDate,
+                                        endDate: festival.endDate
+                                    )
+                                }
+                            }
+                            .padding(.horizontal)
                         }
-                        .padding(.horizontal)
                     }
+                    .padding(.top, -8)
                 }
                 
             }

--- a/unifest-ios/Views/Intro/IntroView.swift
+++ b/unifest-ios/Views/Intro/IntroView.swift
@@ -9,19 +9,18 @@ import SwiftUI
 
 struct IntroView: View {
     @ObservedObject var viewModel: RootViewModel
+    @Environment(\.dismiss) var dismiss
     @State private var likedList: [Int] = []
     @State private var searchText: String = ""
     @State private var count: Int = 0
-    
     // 지역 선택 index
     @State private var regionIndex: Int = 0
     let regions: [String] = ["전체", "서울", "경기∙인천", "강원", "대전∙충청", "광주∙전라", "부산∙대구", "경상"]
-    
     let columns = [GridItem(.adaptive(minimum: 114))]
     
     var body: some View {
         VStack(alignment: .center) {
-            ScrollView {
+            VStack {
                 Spacer()
                     .frame(height: 78)
                 
@@ -40,13 +39,32 @@ struct IntroView: View {
                 Image(.searchBox)
                     .overlay {
                         HStack {
-                            TextField(StringLiterals.Intro.searchPlaceholder, text: $searchText)
-                                .font(.pretendard(weight: .p5, size: 13))
-                                .foregroundStyle(.grey400)
-                            Image(.searchIcon)
+                            TextField("학교/축제 이름을 검색해보세요", text: $searchText)
+                                .font(.system(size: 13))
+                                .onChange(of: searchText) { newValue in
+                                    viewModel.festivalModel.filterFestivals(byKeyword: searchText)
+                                    
+                                    if newValue.isEmpty {
+                                        regionIndex = 0; // '전체'탭으로 전환
+                                        viewModel.festivalModel.festivalSearchResult = viewModel.festivalModel.festivals
+                                    }
+                                }
+                            
+                            if searchText.isEmpty {
+                                Image(.searchIcon)
+                            } else {
+                                Button {
+                                    searchText = ""
+                                    UIApplication.shared.endEditing(true)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundColor(.grey600)
+                                }
+                            }
                         }
                         .padding(.horizontal, 15)
                     }
+                    .padding(.bottom)
                 
                 Spacer()
                     .frame(height: 18)
@@ -87,30 +105,21 @@ struct IntroView: View {
                   }
                   }
                   }*/
-                 /* SchoolBoxView(isSelected: .constant(true), schoolImage: , schoolName: "건국대 서울캠", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )
-                  SchoolBoxView(isSelected: .constant(true), schoolImage: .hongikLogo, schoolName: "홍익대 서울캠", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )
-                  SchoolBoxView(isSelected: .constant(true), schoolImage: .chungangLogo, schoolName: "중앙대 서울캠", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )
-                  SchoolBoxView(isSelected: .constant(true), schoolImage: .snutLogo, schoolName: "서울과기대", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )
-                  SchoolBoxView(isSelected: .constant(true), schoolImage: .uosLogo, schoolName: "서울시립대", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )*/
-                 }
-                 .padding(.horizontal)
-                 }*/
+                 */
                 
-                HStack {
-                    Spacer()
-                        .frame(width: .infinity, height: 7)
-                }
-                .background(.grey100)
-                .frame(width: .infinity, height: 7)
-                .padding(.top, 20)
+                Rectangle()
+                    .fill(.grey100)
+                    .frame(height: 7)
+                    .padding(.top, 20)
                 
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 20) {
-                        ForEach(0 ..< 7) { index in
+                        ForEach(0 ..< regions.count) { index in
                             Button {
                                 withAnimation(.spring) {
                                     regionIndex = index
                                 }
+                                viewModel.festivalModel.filterFestivals(byRegion: regions[index])
                             } label: {
                                 Text(regions[index])
                                     .font(index == regionIndex ? .pretendard(weight: .p7, size: 14) : .pretendard(weight: .p4, size: 14))
@@ -127,66 +136,46 @@ struct IntroView: View {
                     .background(.grey100)
                 
                 HStack {
-                    // Text("총 \(viewModel.festivalModel.festivals.count)개")
-                    //     .font(.system(size: 12))
+                    Text("총 \(viewModel.festivalModel.festivalSearchResult.count)개")
+                        .font(.pretendard(weight: .p5, size: 12))
+                        .foregroundStyle(.grey900)
                     
                     Spacer()
                 }
                 .padding(.horizontal)
                 .padding(.vertical, 5)
                 
-                ScrollView {
-                    LazyVGrid(columns: columns) {
-                        //                        ForEach(viewModel.festivalModel.festivals.filter { $0.region! == regions[regionIndex] }, id: \.self) { festival in
-                        //                            SchoolBoxView(isSelected: .constant(false), schoolImageURL: festival.thumbnail, schoolName: festival.schoolName, festivalName: festival.festivalName, startDate: festival.beginDate, endDate: festival.endDate)
-                        //                        }
-                        /* ForEach(viewModel.festivalModel.festivals.filter { $0.region == regions[regionIndex] }) { festival in
-                         // SchoolBoxView(isSelected: .constant(false), schoolImageURL: festival.thumbnail, schoolName: festival.schoolName, festivalName: festival.festivalName, startDate: festival.beginDate, endDate: festival.endDate)
-                         } */
-                        // let festivalList = viewModel.festivalModel.festivals.filter{ $0.region! == regions[regionIndex] }
-                        let festivalList: [FestivalItem] = viewModel.festivalModel.festivals
-                        
-                        /*  if (regionIndex > 0) {
-                         festivalList = festivalList.filter { $0.region == "서울" }
-                         }*/
-                        
-                        /* ForEach(festivalList, id: \.self) { festival in
-                         if (regionIndex == 0 || festival.region == regions[regionIndex]) {
-                         Image(.nonselectedSchoolBoxBackground)
-                         .resizable()
-                         .scaledToFit()
-                         .frame(width: 113, height: 121)
-                         .overlay {
-                         VStack {
-                         AsyncImage(url: URL(string: festival.thumbnail)) { image in
-                         image.image?
-                         .resizable()
-                         .scaledToFit()
-                         .frame(width: 35, height: 35)
-                         .padding(.bottom, 4)
-                         }
-                         
-                         Text(festival.schoolName)
-                         .font(.system(size: 13))
-                         
-                         Text(festival.festivalName)
-                         .font(.system(size: 12))
-                         .bold()
-                         
-                         Text(formattedDate(from: festival.beginDate) + "-" + formattedDate(from: festival.endDate))
-                         .font(.system(size: 12))
-                         .foregroundStyle(.gray)
-                         }
-                         }
-                         }
-                         }*/
+                
+                if viewModel.festivalModel.festivalSearchResult.isEmpty {
+                    VStack {
+                        Spacer()
+                        Text("검색 결과가 없어요")
+                            .font(.pretendard(weight: .p4, size: 14))
+                            .foregroundStyle(.grey600)
+                        Spacer()
                     }
-                    .padding(.horizontal)
+                } else {
+                    ScrollView {
+                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3), spacing: 10) {
+                            ForEach(viewModel.festivalModel.festivalSearchResult, id: \.festivalId) { festival in
+                                SchoolBoxView(
+                                    isSelected: .constant(false),
+                                    schoolImageURL: festival.thumbnail,
+                                    schoolName: festival.schoolName,
+                                    festivalName: festival.festivalName,
+                                    startDate: festival.beginDate,
+                                    endDate: festival.endDate
+                                )
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
                 }
+                
             }
             
             Button {
-                viewModel.transition(to: .home)
+                dismiss()
             } label: {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(Color.primary500)
@@ -198,9 +187,16 @@ struct IntroView: View {
                     }
             }
             .padding(.horizontal)
+            .padding(.bottom, 7)
         }
         .dynamicTypeSize(.large)
         .background(.ufBackground)
+        .onAppear {
+            // 처음 나타날 때는 모든 축제 다 보여주기
+            viewModel.festivalModel.festivalSearchResult = viewModel.festivalModel.festivals
+            print("festivalSearchResult: ", viewModel.festivalModel.festivalSearchResult)
+            print("festivals: ",viewModel.festivalModel.festivals)
+        }
     }
     
     @ViewBuilder

--- a/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
+++ b/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
@@ -14,11 +14,12 @@ import SwiftUI
 struct EditFavoriteFestivalView: View {
     @State private var searchText: String = ""
     let columns = [GridItem(.adaptive(minimum: 114))]
+    @ObservedObject var viewModel: RootViewModel
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        GeometryReader { geometry in
-            VStack {
+        ScrollView {
+            LazyVStack {
                 Spacer()
                     .frame(height: 30)
                 
@@ -28,7 +29,25 @@ struct EditFavoriteFestivalView: View {
                         HStack {
                             TextField("학교/축제 이름을 검색해보세요", text: $searchText)
                                 .font(.system(size: 13))
-                            Image(.searchIcon)
+                                .onChange(of: searchText) { newValue in
+                                    viewModel.festivalModel.searchFestival(by: searchText)
+                                    
+                                    if newValue.isEmpty {
+                                        viewModel.festivalModel.festivalSearchResult = viewModel.festivalModel.festivals
+                                    }
+                                }
+                            
+                            if searchText.isEmpty {
+                                Image(.searchIcon)
+                            } else {
+                                Button {
+                                    searchText = ""
+                                    UIApplication.shared.endEditing(true)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundColor(.grey600)
+                                }
+                            }
                         }
                         .padding(.horizontal, 15)
                     }
@@ -36,18 +55,24 @@ struct EditFavoriteFestivalView: View {
                 
                 HStack {
                     Text("검색결과")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.gray)
-                    Text("총 2개")
-                        .font(.system(size: 12))
+                        .font(.pretendard(weight: .p5, size: 12))
+                        .foregroundStyle(.grey600)
+                    Text("총 \(viewModel.festivalModel.festivalSearchResult.count)개")
+                        .font(.pretendard(weight: .p5, size: 12))
+                        .foregroundStyle(.grey900)
                     Spacer()
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 8)
                 
-                VStack(spacing: 10) {
-                    LongSchoolBoxView(schoolName: "건국대학교", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08.")
-                    LongSchoolBoxView(schoolName: "건국대학교", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08.")
+                ForEach(viewModel.festivalModel.festivalSearchResult, id: \.festivalId) { festival in
+                    LongSchoolBoxView(
+                        thumbnail: festival.thumbnail,
+                        schoolName: festival.schoolName,
+                        festivalName: festival.festivalName,
+                        startDate: formatDate(festival.beginDate),
+                        endDate: formatDate(festival.endDate)
+                    )
                 }
                 .padding(.horizontal, 15)
                 .padding(.bottom, 6)
@@ -69,7 +94,7 @@ struct EditFavoriteFestivalView: View {
                 
                 ScrollView {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3), spacing: 10) {
-                        SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISJdC2wkhYUte4N5YZ0j-nB_aT_CagQLTOjNDeXMW_kFBeXIe5-pAXDE4CGNVGJ5FMGuS1HUqUTYGfL3AUVJBzum3Ppq5wIUej0v10WuSuOWDT2KIEQwKqA4qiWm3EzS123Uj1gyShvzqaaScOgNsnPg.svg", schoolName: "건국대 서울캠", festivalName: "녹색지대", startDate: "2024-06-24", endDate: "2024-06-27" )
+                        SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISJdC2wkhYUte4N5YZ0j-nB_aT_CagQLTOjNDeXMW_kFBeXIe5-pAXDE4CGNVGJ5FMGuS1HUqUTYGfL3AUVJBzum3Ppq5wIUej0v10WuSuOWDT2KIEQwKqA4qiWm3EzS123Uj1gyShvzqaaScOgNsnPg.svg", schoolName: "건국대 서울캠", festivalName: "녹색지대", startDate: "2024-06-24", endDate: "2024-06-27")
                         SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISOJycKA-weZiZnZjURRWrVUG1b_6EwEV_XC-T4m0L4tkaLMTrYTt-rg9NsoFAvLcaensvvbxtHJniiJ1ozZQASIXrFBKslQibGRszyoIcpf3Amebt_bZ5rNEYbYSQfkbq21wvQuDNQ5jTqtP1RO3V1g.svg", schoolName: "홍익대 서울캠", festivalName: "녹색지대", startDate: "2024-05-20", endDate: "2024-05-24")
                         SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISFfwnU-dlgVpQbZ03CrSG0G0U1cfjhp8ygrXEpeJ_s7b0p6hOl8NgkZyZBV-0dSGl1pKcPaPxpTXHqETtFYKDL_QG8Pu1Qa5-79V0ks6ABzw0eOMDa68Hfpunt1HWPZ17GlqMo8zFONfTmVx7HJGfa4.webp", schoolName: "서울대 관악캠", festivalName: "녹색지대", startDate: "2024-06-01", endDate: "2024-06-04")
                         /* SchoolBoxView(isSelected: .constant(false), schoolImage: .snutLogo, schoolName: "서울과기대", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )
@@ -78,15 +103,27 @@ struct EditFavoriteFestivalView: View {
                     .padding(.horizontal)
                 }
             }
+            .onAppear {
+                // 처음 나타날 때는 모든 축제 다 보여주기
+                viewModel.festivalModel.festivalSearchResult = viewModel.festivalModel.festivals
+                print("festivalSearchResult: \(viewModel.festivalModel.festivalSearchResult)")
+            }
+            .dynamicTypeSize(.large)
         }
-        .dynamicTypeSize(.large)
     }
-}
-
-#Preview {
-    Text("")
-        .sheet(isPresented: .constant(true)) {
-            EditFavoriteFestivalView()
-                .presentationDragIndicator(.visible)
+    
+    func formatDate(_ dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        guard let date = dateFormatter.date(from: dateString) else {
+            return ""
         }
+        
+        // Format month and day
+        let month = Calendar.current.component(.month, from: date)
+        let day = Calendar.current.component(.day, from: date)
+        
+        return "\(month).\(day)"
+    }
 }

--- a/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
+++ b/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
@@ -1,5 +1,5 @@
 //
-//  SearchSchoolView.swift
+//  AddFavoriteFestivalView.swift
 //  unifest-ios
 //
 //  Created by Hoeun Lee on 3/24/24.
@@ -11,7 +11,7 @@ import SwiftUI
 // 검색을 하지 않았을 때는 '나의 관심축제' 뷰 <- SchoolBoxView
 // 검색을 했을 때는 '검색 결과' 뷰가 보이게 만듦 <- LongSchoolBoxView
 
-struct SearchSchoolView: View {
+struct EditFavoriteFestivalView: View {
     @State private var searchText: String = ""
     let columns = [GridItem(.adaptive(minimum: 114))]
     @Environment(\.dismiss) var dismiss
@@ -86,7 +86,7 @@ struct SearchSchoolView: View {
 #Preview {
     Text("")
         .sheet(isPresented: .constant(true)) {
-            SearchSchoolView()
+            EditFavoriteFestivalView()
                 .presentationDragIndicator(.visible)
         }
 }

--- a/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
+++ b/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
@@ -77,10 +77,9 @@ struct EditFavoriteFestivalView: View {
                 .padding(.horizontal, 15)
                 .padding(.bottom, 6)
                 
-                Image(.boldLine)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity)
+                Rectangle()
+                    .fill(.grey100)
+                    .frame(height: 8)
                 
                 HStack {
                     Text("나의 관심 축제")

--- a/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
+++ b/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
@@ -83,8 +83,8 @@ struct EditFavoriteFestivalView: View {
                 
                 HStack {
                     Text("나의 관심 축제")
-                        .font(.system(size: 15))
-                        .fontWeight(.semibold)
+                        .font(.pretendard(weight: .p6, size: 15))
+                        .foregroundStyle(.grey900)
                     
                     Spacer()
                 }
@@ -93,11 +93,16 @@ struct EditFavoriteFestivalView: View {
                 
                 ScrollView {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3), spacing: 10) {
-                        SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISJdC2wkhYUte4N5YZ0j-nB_aT_CagQLTOjNDeXMW_kFBeXIe5-pAXDE4CGNVGJ5FMGuS1HUqUTYGfL3AUVJBzum3Ppq5wIUej0v10WuSuOWDT2KIEQwKqA4qiWm3EzS123Uj1gyShvzqaaScOgNsnPg.svg", schoolName: "건국대 서울캠", festivalName: "녹색지대", startDate: "2024-06-24", endDate: "2024-06-27")
-                        SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISOJycKA-weZiZnZjURRWrVUG1b_6EwEV_XC-T4m0L4tkaLMTrYTt-rg9NsoFAvLcaensvvbxtHJniiJ1ozZQASIXrFBKslQibGRszyoIcpf3Amebt_bZ5rNEYbYSQfkbq21wvQuDNQ5jTqtP1RO3V1g.svg", schoolName: "홍익대 서울캠", festivalName: "녹색지대", startDate: "2024-05-20", endDate: "2024-05-24")
-                        SchoolBoxView(isSelected: .constant(false), schoolImageURL: "https://i.namu.wiki/i/frJ2JwLkp_Ts8Le-AVmISFfwnU-dlgVpQbZ03CrSG0G0U1cfjhp8ygrXEpeJ_s7b0p6hOl8NgkZyZBV-0dSGl1pKcPaPxpTXHqETtFYKDL_QG8Pu1Qa5-79V0ks6ABzw0eOMDa68Hfpunt1HWPZ17GlqMo8zFONfTmVx7HJGfa4.webp", schoolName: "서울대 관악캠", festivalName: "녹색지대", startDate: "2024-06-01", endDate: "2024-06-04")
-                        /* SchoolBoxView(isSelected: .constant(false), schoolImage: .snutLogo, schoolName: "서울과기대", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )
-                         SchoolBoxView(isSelected: .constant(false), schoolImage: .uosLogo, schoolName: "서울시립대", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08." )*/
+                        ForEach(viewModel.festivalModel.festivalSearchResult, id: \.festivalId) { festival in
+                            SchoolBoxView(
+                                isSelected: .constant(false),
+                                schoolImageURL: festival.thumbnail,
+                                schoolName: festival.schoolName,
+                                festivalName: festival.festivalName,
+                                startDate: festival.beginDate,
+                                endDate: festival.endDate
+                            )
+                        }
                     }
                     .padding(.horizontal)
                 }

--- a/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
+++ b/unifest-ios/Views/Map/EditFavoriteFestivalView.swift
@@ -30,7 +30,7 @@ struct EditFavoriteFestivalView: View {
                             TextField("학교/축제 이름을 검색해보세요", text: $searchText)
                                 .font(.system(size: 13))
                                 .onChange(of: searchText) { newValue in
-                                    viewModel.festivalModel.searchFestival(by: searchText)
+                                    viewModel.festivalModel.filterFestivals(byKeyword: searchText)
                                     
                                     if newValue.isEmpty {
                                         viewModel.festivalModel.festivalSearchResult = viewModel.festivalModel.festivals
@@ -131,3 +131,5 @@ struct EditFavoriteFestivalView: View {
         return "\(month).\(day)"
     }
 }
+
+// Preview 오류 발생해서 지움

--- a/unifest-ios/Views/Map/LongSchoolBoxView.swift
+++ b/unifest-ios/Views/Map/LongSchoolBoxView.swift
@@ -55,6 +55,19 @@ struct LongSchoolBoxView: View {
                 }
                 
                 Spacer()
+                
+                Button {
+                    
+                } label: {
+                    Capsule()
+                        .strokeBorder(.primary500, lineWidth: 1)
+                        .frame(width: 57, height: 29)
+                        .overlay {
+                            Text("추가")
+                                .font(.pretendard(weight: .p5, size: 12))
+                                .foregroundStyle(.primary500)
+                        }
+                }
             }
         }
         .padding(.vertical, 2)

--- a/unifest-ios/Views/Map/LongSchoolBoxView.swift
+++ b/unifest-ios/Views/Map/LongSchoolBoxView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct LongSchoolBoxView: View {
+    let thumbnail: String
     let schoolName: String
     let festivalName: String
     let startDate: String
@@ -15,11 +16,28 @@ struct LongSchoolBoxView: View {
     
     var body: some View {
         HStack {
-            Image(.konkukLogo)
-                .resizable()
-                .frame(width: 52, height: 52)
-                .scaledToFit()
-                .padding(.trailing, 4)
+            AsyncImage(url: URL(string: thumbnail)) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image
+                        .resizable()
+                        .frame(width: 52, height: 52)
+                        .scaledToFit()
+                        .clipShape(.circle)
+                        .padding(.trailing, 4)
+                case .failure:
+                    Image(systemName: "photo")
+                        .resizable()
+                        .frame(width: 52, height: 52)
+                        .scaledToFit()
+                        .padding(.trailing, 4)
+                @unknown default:
+                    EmptyView()
+                }
+            }
+            .frame(width: 52, height: 52)
             
             VStack(alignment: .leading) {
                 Text(schoolName)
@@ -35,10 +53,12 @@ struct LongSchoolBoxView: View {
             }
             
             Spacer()
+            
+            
         }
     }
 }
 
 #Preview {
-    LongSchoolBoxView(schoolName: "건국대학교", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08.")
+    LongSchoolBoxView(thumbnail: "", schoolName: "건국대학교", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08.")
 }

--- a/unifest-ios/Views/Map/LongSchoolBoxView.swift
+++ b/unifest-ios/Views/Map/LongSchoolBoxView.swift
@@ -13,6 +13,7 @@ struct LongSchoolBoxView: View {
     let festivalName: String
     let startDate: String
     let endDate: String
+    @EnvironmentObject var favoriteFestivalVM: FavoriteFestivalViewModel
     
     var body: some View {
         VStack {
@@ -29,11 +30,10 @@ struct LongSchoolBoxView: View {
                             .clipShape(.circle)
                             .padding(.trailing, 4)
                     case .failure:
-                        Image(systemName: "photo")
-                            .resizable()
-                            .frame(width: 52, height: 52)
-                            .scaledToFit()
-                            .padding(.trailing, 4)
+                        Circle()
+                            .fill(.grey500)
+                            .frame(width: 35, height: 35)
+                            .padding(.bottom, 4)
                     @unknown default:
                         EmptyView()
                     }
@@ -76,4 +76,5 @@ struct LongSchoolBoxView: View {
 
 #Preview {
     LongSchoolBoxView(thumbnail: "", schoolName: "건국대학교", festivalName: "녹색지대", startDate: "05.06.", endDate: "05.08.")
+        .environmentObject(FavoriteFestivalViewModel(networkManager: NetworkManager()))
 }

--- a/unifest-ios/Views/Map/LongSchoolBoxView.swift
+++ b/unifest-ios/Views/Map/LongSchoolBoxView.swift
@@ -15,47 +15,49 @@ struct LongSchoolBoxView: View {
     let endDate: String
     
     var body: some View {
-        HStack {
-            AsyncImage(url: URL(string: thumbnail)) { phase in
-                switch phase {
-                case .empty:
-                    ProgressView()
-                case .success(let image):
-                    image
-                        .resizable()
-                        .frame(width: 52, height: 52)
-                        .scaledToFit()
-                        .clipShape(.circle)
-                        .padding(.trailing, 4)
-                case .failure:
-                    Image(systemName: "photo")
-                        .resizable()
-                        .frame(width: 52, height: 52)
-                        .scaledToFit()
-                        .padding(.trailing, 4)
-                @unknown default:
-                    EmptyView()
+        VStack {
+            HStack {
+                AsyncImage(url: URL(string: thumbnail)) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .frame(width: 52, height: 52)
+                            .scaledToFit()
+                            .clipShape(.circle)
+                            .padding(.trailing, 4)
+                    case .failure:
+                        Image(systemName: "photo")
+                            .resizable()
+                            .frame(width: 52, height: 52)
+                            .scaledToFit()
+                            .padding(.trailing, 4)
+                    @unknown default:
+                        EmptyView()
+                    }
                 }
-            }
-            .frame(width: 52, height: 52)
-            
-            VStack(alignment: .leading) {
-                Text(schoolName)
-                    .font(.system(size: 13))
+                .frame(width: 52, height: 52)
                 
-                Text(festivalName)
-                    .font(.system(size: 12))
-                    .bold()
+                VStack(alignment: .leading) {
+                    Text(schoolName)
+                        .font(.pretendard(weight: .p4, size: 13))
+                        .foregroundStyle(.grey900)
+                    
+                    Text(festivalName)
+                        .font(.pretendard(weight: .p7, size: 12))
+                        .foregroundStyle(.grey900)
+
+                    Text(startDate + "-" + endDate)
+                        .font(.pretendard(weight: .p4, size: 12))
+                        .foregroundStyle(.grey600)
+                }
                 
-                Text(startDate + "-" + endDate)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.defaultDarkGray)
+                Spacer()
             }
-            
-            Spacer()
-            
-            
         }
+        .padding(.vertical, 2)
     }
 }
 

--- a/unifest-ios/Views/Map/MapPageHeaderView.swift
+++ b/unifest-ios/Views/Map/MapPageHeaderView.swift
@@ -48,10 +48,13 @@ struct MapPageHeaderView: View {
                     .onAppear {
                         isInfoTextPresented = true
                         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                            withAnimation(.easeOut(duration: 1.5)) {
+                            withAnimation(.easeOut(duration: 1.2)) {
                                 isInfoTextPresented = false
                             }
                         }
+                    }
+                    .onTapGesture {
+                        isInfoTextPresented = false
                     }
                 
                 Spacer()

--- a/unifest-ios/Views/Map/MapPageHeaderView.swift
+++ b/unifest-ios/Views/Map/MapPageHeaderView.swift
@@ -23,18 +23,19 @@ struct MapPageHeaderView: View {
                 } label: {
                     HStack {
                         Text("한국교통대학교")
-                            .font(.pretendard(weight: .p6, size: 20))
+                            .font(.pretendard(weight: .p6, size: 18))
                             .foregroundStyle(.grey900)
                         
                         Image(.downArrow)
                          .resizable()
                          .scaledToFit()
-                         .frame(width: 15, height: 15)
+                         .frame(width: 12, height: 12)
                     }
                 }
                 
-                
                 Image(.blackBubble)
+                    .resizable()
+                    .frame(width: 180, height: 30)
                     .overlay {
                         VStack(alignment: .center) {
                             Text("    여기를 눌러서 학교를 검색해보세요.")
@@ -43,12 +44,15 @@ struct MapPageHeaderView: View {
                                 .padding(.top, 2)
                         }
                     }
-                    .onTapGesture {
-                        withAnimation(.spring(duration: 0.1)) {
-                            isInfoTextPresented = false
+                    .opacity(isInfoTextPresented ? 1 : 0)
+                    .onAppear {
+                        isInfoTextPresented = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            withAnimation(.easeOut(duration: 1.5)) {
+                                isInfoTextPresented = false
+                            }
                         }
                     }
-                    .opacity(isInfoTextPresented ? 1 : 0)
                 
                 Spacer()
                 
@@ -233,7 +237,7 @@ struct MapPageHeaderView: View {
 //            VoteView()
 //        }
         .sheet(isPresented: $isEditFavoriteFestivalViewPresented) {
-            EditFavoriteFestivalView()
+            EditFavoriteFestivalView(viewModel: viewModel)
                 .presentationDragIndicator(.visible)
             // .presentationDetents([.height(700)])
         }

--- a/unifest-ios/Views/Map/MapPageHeaderView.swift
+++ b/unifest-ios/Views/Map/MapPageHeaderView.swift
@@ -12,43 +12,43 @@ struct MapPageHeaderView: View {
     @ObservedObject var mapViewModel: MapViewModel
     @State private var isInfoTextPresented: Bool = true
     @Binding var searchText: String
-    @State private var isSearchSchoolViewPresented = false
+    @State private var isEditFavoriteFestivalViewPresented = false
     @State private var isVoteViewPresented = false
     
     var body: some View {
         VStack {
             HStack {
-//                Button {
-//                    isSearchSchoolViewPresented = true
-//                } label: {
+                Button {
+                    isEditFavoriteFestivalViewPresented = true
+                } label: {
                     HStack {
                         Text("한국교통대학교")
                             .font(.pretendard(weight: .p6, size: 20))
                             .foregroundStyle(.grey900)
                         
-                        /* Image(.downArrow)
+                        Image(.downArrow)
                          .resizable()
                          .scaledToFit()
-                         .frame(width: 16, height: 16) */
+                         .frame(width: 15, height: 15)
                     }
-//                }
+                }
                 
-                /*
-                 Image(.blackBubble)
-                 .overlay {
-                 VStack(alignment: .center) {
-                 Text("여기를 눌러서 학교를 검색해보세요.")
-                 .font(.system(size: 11))
-                 .foregroundStyle(.white)
-                 .padding(.top, 2)
-                 }
-                 }
-                 .onTapGesture {
-                 withAnimation(.spring(duration: 0.1)) {
-                 isInfoTextPresented = false
-                 }
-                 }
-                 .opacity(isInfoTextPresented ? 1 : 0)*/
+                
+                Image(.blackBubble)
+                    .overlay {
+                        VStack(alignment: .center) {
+                            Text("    여기를 눌러서 학교를 검색해보세요.")
+                                .font(.pretendard(weight: .p5, size: 11))
+                                .foregroundStyle(.white)
+                                .padding(.top, 2)
+                        }
+                    }
+                    .onTapGesture {
+                        withAnimation(.spring(duration: 0.1)) {
+                            isInfoTextPresented = false
+                        }
+                    }
+                    .opacity(isInfoTextPresented ? 1 : 0)
                 
                 Spacer()
                 
@@ -232,11 +232,11 @@ struct MapPageHeaderView: View {
 //        .fullScreenCover(isPresented: $isVoteViewPresented) {
 //            VoteView()
 //        }
-//        .sheet(isPresented: $isSearchSchoolViewPresented) {
-//            SearchSchoolView()
-//                .presentationDragIndicator(.visible)
-//            // .presentationDetents([.height(700)])
-//        }
+        .sheet(isPresented: $isEditFavoriteFestivalViewPresented) {
+            EditFavoriteFestivalView()
+                .presentationDragIndicator(.visible)
+            // .presentationDetents([.height(700)])
+        }
     }
 }
 

--- a/unifest-ios/Views/Map/MapPageView.swift
+++ b/unifest-ios/Views/Map/MapPageView.swift
@@ -39,7 +39,6 @@ struct MapPageView: View {
                 }
                 
                 VStack {
-                    // MapPageHeaderView(searchText: $searchText, isTagSelected: $isTagSelected, isSearchSchoolViewPresented: $isSearchSchoolViewPresented, isPopularBoothPresented: $isPopularBoothPresented)
                     MapPageHeaderView(viewModel: viewModel, mapViewModel: mapViewModel, searchText: $searchText)
                         .background(.ufBackground)
                         .clipShape(

--- a/unifest-ios/Views/Map/SchoolBoxView.swift
+++ b/unifest-ios/Views/Map/SchoolBoxView.swift
@@ -17,28 +17,45 @@ struct SchoolBoxView: View {
     
     var body: some View {
         RoundedRectangle(cornerRadius: 10)
-            .stroke(.lightGray)
+            .strokeBorder(.grey300)
             .frame(height: 120)
             .overlay {
                 VStack {
-                    AsyncImage(url: URL(string: schoolImageURL)) { image in
-                        image.image?
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 35, height: 35)
-                            .padding(.bottom, 4)
+                    AsyncImage(url: URL(string: schoolImageURL)) { phase in
+                        switch phase {
+                        case .empty:
+                            ProgressView()
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .frame(width: 35, height: 35)
+                                .scaledToFit()
+                                .clipShape(.circle)
+                                .padding(.bottom, 4)
+                        case .failure:
+                            Image(systemName: "photo")
+                                .resizable()
+                                .frame(width: 35, height: 35)
+                                .scaledToFit()
+                                .clipShape(.circle)
+                                .padding(.bottom, 4)
+                        @unknown default:
+                            EmptyView()
+                        }
                     }
+                    .frame(width: 35, height: 35)
                     
                     Text(schoolName)
-                        .font(.system(size: 13))
+                        .font(.pretendard(weight: .p4, size: 13))
+                        .foregroundStyle(.grey900)
                     
                     Text(festivalName)
-                        .font(.system(size: 12))
-                        .bold()
+                        .font(.pretendard(weight: .p7, size: 12))
+                        .foregroundStyle(.grey900)
                     
                     Text(formattedDate(from: startDate) + "-" + formattedDate(from: endDate))
-                        .font(.system(size: 12))
-                        .foregroundStyle(.gray)
+                        .font(.pretendard(weight: .p4, size: 12))
+                        .foregroundStyle(.grey600)
                 }
             }
     }

--- a/unifest-ios/Views/Map/SchoolBoxView.swift
+++ b/unifest-ios/Views/Map/SchoolBoxView.swift
@@ -33,11 +33,9 @@ struct SchoolBoxView: View {
                                 .clipShape(.circle)
                                 .padding(.bottom, 4)
                         case .failure:
-                            Image(systemName: "photo")
-                                .resizable()
+                            Circle()
+                                .fill(.grey500)
                                 .frame(width: 35, height: 35)
-                                .scaledToFit()
-                                .clipShape(.circle)
                                 .padding(.bottom, 4)
                         @unknown default:
                             EmptyView()

--- a/unifest-ios/Views/Menu/MenuView.swift
+++ b/unifest-ios/Views/Menu/MenuView.swift
@@ -16,6 +16,7 @@ struct MenuView: View {
     @EnvironmentObject var networkManager: NetworkManager
     @EnvironmentObject var tabSelect: TabSelect
     @State private var isListViewPresented: Bool = false
+    @State private var isEditFavoriteFestivalViewPresented: Bool = false
     @State private var tappedBoothId = 0
     @State private var isDetailViewPresented: Bool = false
     @State private var randomLikeList: [Int] = []
@@ -52,19 +53,19 @@ struct MenuView: View {
                     Spacer()
                     
                     
-                    /* Button {
-                     
-                     } label: {
-                     HStack(spacing: 0) {
-                     Text("추가하기")
-                     .font(.system(size: 11))
-                     .foregroundColor(.gray)
-                     .underline()
-                     Image(systemName: "chevron.right")
-                     .font(.system(size: 11))
-                     .foregroundColor(.gray)
-                     }
-                     } */
+                    Button {
+                        isEditFavoriteFestivalViewPresented = true
+                    } label: {
+                        HStack(spacing: 0) {
+                            Text("추가하기 >")
+                                .font(.pretendard(weight: .p6, size: 11))
+                                .foregroundColor(.grey600)
+                                .underline()
+//                            Image(systemName: "chevron.right")
+//                                .font(.system(size: 10))
+//                                .foregroundColor(.grey600)
+                        }
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 10)
@@ -854,6 +855,10 @@ struct MenuView: View {
             LikeBoothListView(viewModel: viewModel)
                 .ignoresSafeArea()
         })
+        .sheet(isPresented: $isEditFavoriteFestivalViewPresented) {
+            EditFavoriteFestivalView(viewModel: viewModel)
+                .presentationDragIndicator(.visible)
+        }
         .onAppear {
             // boothModel.likedBoothList = [1, 2, 3, 78, 79, 80, 81, 82]
             randomLikeList = viewModel.boothModel.getRandomLikedBooths()

--- a/unifest-ios/Views/Menu/MenuView.swift
+++ b/unifest-ios/Views/Menu/MenuView.swift
@@ -16,7 +16,7 @@ struct MenuView: View {
     @EnvironmentObject var networkManager: NetworkManager
     @EnvironmentObject var tabSelect: TabSelect
     @State private var isListViewPresented: Bool = false
-    @State private var isEditFavoriteFestivalViewPresented: Bool = false
+    @State private var isIntroViewPresented: Bool = false
     @State private var tappedBoothId = 0
     @State private var isDetailViewPresented: Bool = false
     @State private var randomLikeList: [Int] = []
@@ -54,7 +54,7 @@ struct MenuView: View {
                     
                     
                     Button {
-                        isEditFavoriteFestivalViewPresented = true
+                        isIntroViewPresented = true
                     } label: {
                         HStack(spacing: 0) {
                             Text("추가하기 >")
@@ -125,12 +125,12 @@ struct MenuView: View {
                         } label: {
                             HStack(spacing: 0) {
                                 Text(StringLiterals.Menu.more)
-                                    .font(.system(size: 11))
+                                    .font(.pretendard(weight: .p6, size: 11))
+                                    .foregroundStyle(.grey600)
                                     .underline()
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 11))
+//                                Image(systemName: "chevron.right")
+//                                    .font(.system(size: 11))
                             }
-                            .foregroundStyle(.grey600)
                         }
                     }
                 }
@@ -855,8 +855,8 @@ struct MenuView: View {
             LikeBoothListView(viewModel: viewModel)
                 .ignoresSafeArea()
         })
-        .sheet(isPresented: $isEditFavoriteFestivalViewPresented) {
-            EditFavoriteFestivalView(viewModel: viewModel)
+        .sheet(isPresented: $isIntroViewPresented) {
+            IntroView(viewModel: viewModel)
                 .presentationDragIndicator(.visible)
         }
         .onAppear {

--- a/unifest-ios/Views/Root/RootView.swift
+++ b/unifest-ios/Views/Root/RootView.swift
@@ -22,6 +22,7 @@ struct RootView: View {
     @State private var appVersionAlertPresented: Bool = false
     @State private var isWelcomeViewPresented: Bool = false
     @State private var isBoothDetailViewPresented: Bool = false
+    @State private var isIntroViewPresented: Bool = false
     @State private var selectedBoothId = 0
     
     init(rootViewModel: RootViewModel, networkManager: NetworkManager) {
@@ -204,8 +205,14 @@ struct RootView: View {
                 }
                 .onDisappear {
                     UserDefaults.standard.set(true, forKey: "IS_FIRST_LAUNCH")
+                    withAnimation(.easeInOut) {
+                        isIntroViewPresented = true
+                    }
                 }
                 .presentationDragIndicator(.visible)
+        }
+        .fullScreenCover(isPresented: $isIntroViewPresented) {
+            IntroView(viewModel: viewModel)
         }
         .alert("유니페스 업데이트 안내", isPresented: $appVersionAlertPresented, actions: {
             Button("업데이트") {

--- a/unifest-ios/Views/Welcome/WelcomeView.swift
+++ b/unifest-ios/Views/Welcome/WelcomeView.swift
@@ -44,12 +44,12 @@ struct WelcomeView: View {
             // 안내
             ScrollView {
                 VStack(alignment: .center, spacing: 10,content: {
-                    WelcomeRow(iconName: "calendar.circle", mainColor: .accent, title: "캘린더로 대학 축제 일정 확인", subtitle: "오늘은 어느 대학 축제에 갈까? 캘린더에서 한눈에 \n다른 학교의 축제와 공연 일정까지 확인할 수 있어요")
-                    WelcomeRow(iconName: "map.circle", mainColor: .yellow, title: "지도로 보는 각 부스 위치", subtitle: "주점이 어디더라?\n찾고 있는 부스를 지도에서 쉽게 확인하세요")
-                    WelcomeRow(iconName: "questionmark.circle", mainColor: .blue, title: "한 눈에 보는 부스 정보", subtitle: "이 주점 메뉴는 뭐지? 부스에서 판매중인 메뉴, \n기념품, 이벤트 정보를 손쉽게 확인해보세요")
-                    WelcomeRow(iconName: "person.2.circle", mainColor: .green, title: "축제 인기부스 보기", subtitle: "지금 인기있는 부스는 어디? \n실시간으로 인기 있는 부스를 확인할 수 있어요")
-                    WelcomeRow(iconName: "hourglass.circle", mainColor: .purple, title: "부스 웨이팅 신청하기", subtitle: "웨이팅하는 동안 액티비티나 즐겨볼까? \n입장을 원하는 부스에 웨이팅을 신청하고 축제를 더 알차게 즐겨보세요")
-                    WelcomeRow(iconName: "star.circle", mainColor: .mint, title: "스탬프 받기", subtitle: "부스에서 스탬프를 받으며 축제에 더 적극적으로 참여해보세요")
+                    WelcomeRow(iconName: "calendar.circle", mainColor: .accent, title: "캘린더로 대학 축제 일정 확인", subtitle: "오늘은 어느 대학 축제에 갈까? 캘린더에서 한눈에 \n다른 학교의 축제와 공연 일정까지 확인할 수 있어요.")
+                    WelcomeRow(iconName: "map.circle", mainColor: .yellow, title: "지도로 보는 각 부스 위치", subtitle: "주점이 어디더라?\n찾고 있는 부스를 지도에서 쉽게 확인하세요.")
+                    WelcomeRow(iconName: "questionmark.circle", mainColor: .blue, title: "한 눈에 보는 부스 정보", subtitle: "이 주점 메뉴는 뭐지? 부스에서 판매중인 메뉴, \n기념품, 이벤트 정보를 손쉽게 확인해보세요.")
+                    WelcomeRow(iconName: "person.2.circle", mainColor: .green, title: "축제 인기부스 보기", subtitle: "지금 인기있는 부스는 어디? \n실시간으로 인기 있는 부스를 확인할 수 있어요.")
+                    WelcomeRow(iconName: "hourglass.circle", mainColor: .purple, title: "부스 웨이팅 신청하기", subtitle: "웨이팅하는 동안 액티비티나 즐겨볼까? \n입장을 원하는 부스에 웨이팅을 신청하고 축제를 더 알차게 즐겨보세요.")
+                    WelcomeRow(iconName: "star.circle", mainColor: .mint, title: "스탬프 받기", subtitle: "부스에서 스탬프를 받으며 축제에 더 적극적으로 참여해보세요.")
                 })
                 .padding()
             }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue

- 관심축제를 추가/삭제하는 화면과 관련 기능 구현 및 리팩토링 진행

### 🌟Motivation

<br/>


### 🌟Key Changes

- **뷰 디자인**
  - `EditFavoriteFestivalView`와 `IntroView`의 UI 설계 및 다크모드 지원
  - `EditFavoriteFestivalView`는 지도 탭에서 학교명을 탭했을 때 `sheet`로 표시되도록 구현
  - `IntroView`는 앱 첫 실행 시 및 메뉴 탭에서 '관심 축제 수정하기' 버튼 클릭 시 `sheet`로 표시되도록 구현
  
- **기능 구현**
  - **FestivalModel**
    - `filterFestivals(byKeyword:)`와 `filterFestivals(byRegion:)` 메서드 추가
      - 검색 조건에 따라 축제를 필터링하며, 메서드 오버로딩을 적용
      - 검색어가 영어일 경우 대소문자를 구분하지 않도록 구현
      - 학교 이름 혹은 축제 이름으로 원하는 학교/축제 검색 가능
    - `festivalSearchResult` 배열 추가: 필터링 결과를 저장함
  - `EditFavoriteFestivalView` 및 `IntroView`에서:
    - 기본 동작으로는 모든 축제를 표시하도록 구현 (뷰가 최초로 렌더링될 때 또는 검색어가 비어 있을 때)
    - 사용자가 입력한 검색 조건(지역, 검색어)에 따라 필터링된 축제 결과를 표시
  
- **리팩토링**
  - 기존 `SearchSchoolView` 명칭을 `EditFavoriteFestivalView`로 변경
  - 일부 뷰의 padding값을 조절하고 뷰의 비율을 조정해 UI 개선 

<br/>

### 🌟Simulation

https://github.com/user-attachments/assets/5a90d75b-e9bb-49dc-a3f5-bde1f215cf65


### 🌟To Reviewer

### 🌟Reference

<br/>
