### PR TITLE
[Feat] 가천대를 자동으로 관심 축제에 등록하는 기능 추가

### DIFF
--- a/unifest-ios/AppDelegate.swift
+++ b/unifest-ios/AppDelegate.swift
@@ -124,7 +124,7 @@ extension AppDelegate: MessagingDelegate {
 }
 
 // MARK: 가천대학교 특화기간동안 사용하는 코드입니다.
-extension AppDelegate {
+private extension AppDelegate {
     func addGachonFavorite() async {
         let gachonFestivalId = 15
         let deviceId = DeviceUUIDManager.shared.getDeviceToken()

--- a/unifest-ios/AppDelegate.swift
+++ b/unifest-ios/AppDelegate.swift
@@ -14,6 +14,7 @@ import Firebase
 import UserNotifications
 import FirebaseCore
 import FirebaseMessaging
+import Alamofire
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
@@ -116,5 +117,36 @@ extension AppDelegate: MessagingDelegate {
         )
         // TODO: If necessary send token to application server.
         // Note: This callback is fired at each app startup and whenever a new token is generated.
+    }
+}
+
+// MARK: 가천대학교 특화기간동안 사용하는 코드입니다.
+extension AppDelegate {
+    func addGachonFavorite() async {
+        let gachonFestivalId = 15
+        let deviceId = DeviceUUIDManager.shared.getDeviceToken()
+
+        let url = NetworkUtils.buildURL(for: APIEndpoint.FavoriteFestival.addFavoriteFestival(festivalId: gachonFestivalId))
+        let headers: HTTPHeaders = [
+            .accept("application/json"),
+            .contentType("application/json")
+        ]
+        let parameters: [String: Any] = [
+            "deviceId": deviceId
+        ]
+        
+        do {
+            let apiClient = APIClient()
+            let response: AddFavoriteFestivalResponse = try await apiClient.post(
+                url: url,
+                headers: headers,
+                parameters: parameters,
+                responseType: AddFavoriteFestivalResponse.self
+            )
+            print("AddFavoriteFestival request succeeded")
+            print(response)
+        } catch {
+            print("AddFavoriteFestival request failed")
+        }
     }
 }

--- a/unifest-ios/AppDelegate.swift
+++ b/unifest-ios/AppDelegate.swift
@@ -117,6 +117,9 @@ extension AppDelegate: MessagingDelegate {
         )
         // TODO: If necessary send token to application server.
         // Note: This callback is fired at each app startup and whenever a new token is generated.
+        Task {
+            await addGachonFavorite()
+        }
     }
 }
 

--- a/unifest-ios/Networking/APIManager.swift
+++ b/unifest-ios/Networking/APIManager.swift
@@ -11,7 +11,11 @@ import SwiftUI
 
 final class APIManager: ObservableObject {
     
+#if DEBUG
+    static let shared = APIManager(serverType: .dev)
+#else
     static let shared = APIManager(serverType: .prod)
+#endif
     private var cancellables = Set<AnyCancellable>()
     
     // API 서버 종류별 address


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue

- #80 

### 🌟Motivation

가천대 특화 요구사항에 따른 기능 추가

### 🌟Key Changes

앱 시작 시 가천대를 자동으로 관심 축제에 등록합니다.
- AppDelegate는 앱 시작 시 FCM토큰을 등록합니다.
- 토큰등록 시의 콜백 함수가 가천대를 관심 축제로 등록하는 API를 호출하도록 메서드를 추가했습니다.

### 🌟Simulation

브랜치가 달라.. #81 머지 후에 추가할 수 있슴니다..