### PR TITLE
[Fix] 부스 웨이팅 시 정확한 Pin 입력시에도 에러를 반환하는 이슈를 해결합니다.

### DIFF
--- a/unifest-ios/Views/Detail/WaitingPinView.swift
+++ b/unifest-ios/Views/Detail/WaitingPinView.swift
@@ -121,7 +121,8 @@ struct WaitingPinView: View {
                             Button {
                                 Task {
                                     isCheckingPin = true
-                                    await waitingVM.checkPinNumber(boothId: boothId, pinNumber: pin)
+                                    print("buttonTapped boothId: \(viewModel.boothModel.selectedBoothID)")
+                                    await waitingVM.checkPinNumber(boothId: viewModel.boothModel.selectedBoothID, pinNumber: pin)
                                     
                                     if waitingVM.isPinNumberValid == true {
                                         isWaitingPinViewPresented = false

--- a/unifest-ios/Views/Map/MapPageView.swift
+++ b/unifest-ios/Views/Map/MapPageView.swift
@@ -181,7 +181,7 @@ struct MapPageView: View {
             }
             .ignoresSafeArea()
             .sheet(isPresented: $isBoothDetailViewPresented) {
-                BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: tappedBoothId)
+                BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: viewModel.boothModel.selectedBoothID)
                     .presentationDragIndicator(.visible)
             }
             .fullScreenCover(isPresented: $isBoothMapViewPresented) {

--- a/unifest-ios/Views/Menu/LikeBoothListView.swift
+++ b/unifest-ios/Views/Menu/LikeBoothListView.swift
@@ -143,7 +143,7 @@ struct LikeBoothListView: View {
         .dynamicTypeSize(.large)
         .background(.ufBackground)
         .sheet(isPresented: $isDetailViewPresented) {
-            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: tappedBoothId)
+            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: viewModel.boothModel.selectedBoothID)
                 .presentationDragIndicator(.visible)
         }
     }

--- a/unifest-ios/Views/Menu/MenuView.swift
+++ b/unifest-ios/Views/Menu/MenuView.swift
@@ -622,7 +622,7 @@ struct MenuView: View {
             await favoriteFestivalVM.getFavoriteFestivalList(deviceId: DeviceUUIDManager.shared.getDeviceToken())
         }
         .sheet(isPresented: $isDetailViewPresented) {
-            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: tappedBoothId)
+            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: viewModel.boothModel.selectedBoothID)
                 .presentationDragIndicator(.visible)
                 .onAppear {
                     GATracking.eventScreenView(GATracking.ScreenNames.likedBoothListView)

--- a/unifest-ios/Views/Root/RootView.swift
+++ b/unifest-ios/Views/Root/RootView.swift
@@ -203,7 +203,7 @@ struct RootView: View {
             }
         }
         .sheet(isPresented: $isBoothDetailViewPresented) {
-            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: selectedBoothId)
+            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: viewModel.boothModel.selectedBoothID)
                 .environmentObject(waitingVM)
                 .environmentObject(networkManager)
                 .presentationDragIndicator(.visible)

--- a/unifest-ios/Views/Stamp/StampBoothListItemView.swift
+++ b/unifest-ios/Views/Stamp/StampBoothListItemView.swift
@@ -88,7 +88,7 @@ struct StampBoothListItemView: View {
             isBoothDetailViewPresented = true
         }
         .sheet(isPresented: $isBoothDetailViewPresented) {
-            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: boothID)
+            BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: viewModel.boothModel.selectedBoothID)
         }
     }
 }

--- a/unifest-ios/Views/Waiting/WaitingInfoView.swift
+++ b/unifest-ios/Views/Waiting/WaitingInfoView.swift
@@ -122,7 +122,7 @@ struct WaitingInfoView: View {
                         .padding() // RoundedRectangle() 안쪽 padding
                     }
                     .sheet(isPresented: $isBoothDetailViewPresented) {
-                        BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: 156)
+                        BoothDetailView(viewModel: viewModel, mapViewModel: mapViewModel, currentBoothId: viewModel.boothModel.selectedBoothID)
                             .presentationDragIndicator(.visible)
                     }
                     .frame(width: geometry.size.width * 0.9) // 중앙 정렬을 위해 frame을 명시적으로 지정


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용
Ex) 
// 1번 이슈에서 새로운 기능(Feat)을 구현한 경우
[Feat] #1 - 기능 구현
// 1번 이슈에서 레이아웃(Design)을 구현한 경우
[Design] #1 - 레이아웃 구현

Prefix

[Design]: 뷰 짜기
[Feat]: 새로운 기능 구현
[Network]: 네트워크 연결
[Fix]: 버그, 오류 해결, 코드 수정
[Add]: Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 View 생성
[Del]: 쓸모없는 코드, 주석 삭제
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Docs]: README나 WIKI 등의 문서 개정
[Setting]: 세팅
[Merge]: #이슈번호 - 머지

-->

### ⭐️Issue

- #95 

### 🌟Motivation

가천대 앱 사전사용 중 발생한 400에러를 반환 이슈 해결

### 🌟Key Changes

본 이슈는 tappedBoothId를 현재 선택한 부스로 갱신하지 않아, 기본값인 0이나 이전에 선택한 마커의 boothId로 API를 요청해 발생했습니다.

#### AS-IS
MapPageView의 127~128번 줄, isPopularBoothPresented가 true일 때 진입하는 코드 스코프 내에서
tappedBoothId를 선택한 부스의 id로 갱신하지 않은 채로 isBoothDetailViewPresented를 true로 변경합니다.
이때 present하는 BoothDetailView에 갱신되지 않은 boothId를 주입, 생성하며
이로 인해 BoothDetailView내에 갱신되지 않은 boothId를 WaitingPinView에 주입, 생성합니다.
이에 WaitingPinView에서 기본값인 0 또는 현재 선택하지 않은 boothId로 API를 요청, 이로 인해 400을 반환받아 발생한 이슈입니다.

같은 파일에서, 지도의 마커를 탭해 진입하는 153번 줄의 코드 스코프에서는 163번 줄에서 tappedBoothId를 갱신하고 있습니다.
따라서 지도의 마커를 탭하고, 다시 인기 부스를 탭해 부스 디테일 뷰로 진입하면 상기한 이슈가 이곳에서도 발생합니다.

#### TO-BE
앱 전역에서 BoothDetailView를 호출하기 전 BoothModel.loadBoothDetail() 메서드를 호출하고 있는것을 확인했고
loadBoothDetail() 메서드가 selectedBoothID를 동기로 갱신하며
이후 각 뷰에서 Presented 관련 부울변수를 변경하고 있음 또한 확인했습니다.

이에 해당 메서드를 호출 후 BoothDetailView의 생성자에 currentBoothId 주입 시 BoothModel.selectedBoothID를 주입하도록 변경합니다.
(동기적으로 loadBoothDetail() -> selectedBoothID갱신 -> Presented 갱신 -> BoothDetailView 생성 이 이루어지므로 타이밍 위험 없음)

### 🌟Simulation

| 이슈 해결 전 400 발생 | 이슈 해결 후 |
| - | - |
|![ScreenRecording_09-05-2025 00-15-22_1](https://github.com/user-attachments/assets/2a876562-0fa3-4daa-8353-5f7a578a3281)|![ScreenRecording_09-05-2025 00-21-02_1](https://github.com/user-attachments/assets/c3529304-c804-4582-90e8-931d151422e8)|


### 🌟To Reviewer

상태관리가 이렇게 중요하네요~~
MVI로! 정상화. 진행시켜~!
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/a457a80b-d730-42e5-befd-8990f0d3b115" />
